### PR TITLE
fix: Data storage on Linux

### DIFF
--- a/apps/app/src/electron/storageHandler.ts
+++ b/apps/app/src/electron/storageHandler.ts
@@ -531,6 +531,9 @@ export class StorageHandler extends EventEmitter {
 	}
 	private get _baseFolder() {
 		const homeDirPath = os.homedir()
+		if (os.type() === 'Linux') {
+			return path.join(homeDirPath, '.super-conductor')
+		}
 		return path.join(homeDirPath, 'Documents', 'SuperConductor')
 	}
 	private get _projectId() {


### PR DESCRIPTION
Fixes persisting data on Linux.

On some Linux distributions the `Documents` folder may exist, however, the recommendation of the Linux FHS is to create a directory starting with `.` for application data storage[1], as the exact structure of the home directory has not been standardised by Linux.

This PR will change the `baseFolder` for storage to the equivalent of `$HOME/.super-conductor`, which should work for most users.

[1] See `3.8.2` https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s08.html#ftn.idm236092760560