### PR TITLE
fix: Copy libraries from sharp into final bundle

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -113,7 +113,38 @@
 			"hardenedRuntime": true,
 			"gatekeeperAssess": false,
 			"entitlements": "entitlements.mac.plist",
-			"entitlementsInherit": "entitlements.mac.plist"
+			"entitlementsInherit": "entitlements.mac.plist",
+			"extraFiles": [
+				{
+					"from": "../../node_modules/sharp/vendor/8.12.2/darwin-x64/lib",
+					"to": "Frameworks",
+					"filter": [
+						"!glib-2.0/**/*"
+					]
+				}
+			]
+		},
+		"win": {
+			"extraFiles": [
+				{
+					"from": "../../node_modules/sharp/build/Release",
+					"to": ".",
+					"filter": [
+						"lib*.dll"
+					]
+				}
+			]
+		},
+		"linux": {
+			"extraFiles": [
+				{
+					"from": "../../node_modules/sharp/vendor/8.12.2/linux-x64/lib",
+					"to": ".",
+					"filter": [
+						"libvips*.so.*"
+					]
+				}
+			]
 		},
 		"dmg": {
 			"artifactName": "SuperConductor ${version} macOS Installer.${ext}"


### PR DESCRIPTION
Fixes an issue when starting SuperConductor whereby sharp is unable to find libvips.

I've tested this on a fresh install of Ubuntu 20.04, but not on Windows or Mac.