### PR TITLE
feat: add support for CasparCG transitions

### DIFF
--- a/apps/app/src/lib/TSR.ts
+++ b/apps/app/src/lib/TSR.ts
@@ -1,0 +1,8 @@
+export const ATEM_DEFAULT_TRANSITION_RATE = 25
+
+export function getAtemFrameRate() {
+	// This is just a placeholder for now, assuming a frame rate.
+	// Ideally, we'd be quering the atem device for the frame rate and cache it.
+
+	return 25
+}

--- a/apps/app/src/react/components/rundown/GroupView/TimelineObject.tsx
+++ b/apps/app/src/react/components/rundown/GroupView/TimelineObject.tsx
@@ -374,6 +374,7 @@ export const TimelineObject: React.FC<{
 				left: `${startPercentage}%`,
 				width: widthPercentage !== null ? `${widthPercentage}%` : undefined,
 				right: widthPercentage === null ? '-4px' : undefined,
+				zIndex: Math.round(startPercentage),
 			}}
 			onClick={updateSelection}
 			title={warnings && warnings.length > 0 ? warnings.join(', ') : description.label + ' ' + durationTitle}

--- a/apps/app/src/react/components/rundown/GroupView/TimelineObject.tsx
+++ b/apps/app/src/react/components/rundown/GroupView/TimelineObject.tsx
@@ -423,6 +423,33 @@ export const TimelineObject: React.FC<{
 					setMoveType('duration')
 				}}
 			/>
+			{description.inTransition && (
+				<div
+					className="transition transition--in"
+					style={{
+						width:
+							description.inTransition.duration === undefined
+								? undefined
+								: description.inTransition.duration / msPerPixel,
+					}}
+					title={description.inTransition.label}
+				></div>
+			)}
+			{description.outTransition && (
+				<div
+					className={classNames(
+						'transition transition--out',
+						(widthPercentage === null || widthPercentage > 99) && 'at-end'
+					)}
+					style={{
+						width:
+							description.outTransition.duration === undefined
+								? undefined
+								: description.outTransition.duration / msPerPixel,
+					}}
+					title={description.outTransition.label}
+				></div>
+			)}
 		</div>
 	)
 })

--- a/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/atem.tsx
+++ b/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/atem.tsx
@@ -20,8 +20,7 @@ import { IntInput } from '../../../inputs/IntInput'
 import { EditWrapper, OnSave } from './lib'
 import { Button, Stack, Typography } from '@mui/material'
 import { TrashBtn } from '../../../inputs/TrashBtn'
-
-const DEFAULT_TRANSITION_RATE = 25
+import { ATEM_DEFAULT_TRANSITION_RATE } from '../../../../../lib/TSR'
 
 enum ATEMAudioChannelMixOption {
 	Off = 0,
@@ -80,7 +79,7 @@ export const EditTimelineObjAtemAny: React.FC<{ obj: TimelineObjAtemAny; onSave:
 						<IntInput
 							label={'Transition: Mix Rate'}
 							fullWidth
-							currentValue={obj.content.me.transitionSettings?.mix?.rate ?? DEFAULT_TRANSITION_RATE}
+							currentValue={obj.content.me.transitionSettings?.mix?.rate ?? ATEM_DEFAULT_TRANSITION_RATE}
 							onChange={(v) => {
 								if (!obj.content.me.transitionSettings) obj.content.me.transitionSettings = {}
 								if (!obj.content.me.transitionSettings.mix)
@@ -99,7 +98,9 @@ export const EditTimelineObjAtemAny: React.FC<{ obj: TimelineObjAtemAny; onSave:
 							<IntInput
 								label={'Transition: Rate'}
 								fullWidth
-								currentValue={obj.content.me.transitionSettings?.wipe?.rate ?? DEFAULT_TRANSITION_RATE}
+								currentValue={
+									obj.content.me.transitionSettings?.wipe?.rate ?? ATEM_DEFAULT_TRANSITION_RATE
+								}
 								onChange={(v) => {
 									if (!obj.content.me.transitionSettings) obj.content.me.transitionSettings = {}
 									if (!obj.content.me.transitionSettings.wipe)

--- a/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/osc.tsx
+++ b/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/osc.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, Stack, Typography } from '@mui/material'
 import React from 'react'
 import { OSCMessageCommandContent, OSCValueType, SomeOSCValue, TimelineObjOSCAny } from 'timeline-state-resolver-types'
+import { DurationInput } from '../../../inputs/DurationInput'
 import { FloatInput } from '../../../inputs/FloatInput'
 import { IntInput } from '../../../inputs/IntInput'
 import { SelectEnum } from '../../../inputs/SelectEnum'
@@ -186,16 +187,18 @@ export const EditTimelineObjOSCAny: React.FC<{ obj: TimelineObjOSCAny; onSave: O
 					</Stack>
 
 					<div className="setting">
-						<FloatInput
+						<DurationInput
 							label="Transition Duration (milliseconds)"
 							fullWidth
 							currentValue={obj.content.transition.duration}
+							defaultValue={0}
 							onChange={(v) => {
 								if (!obj.content.transition) obj.content.transition = DEFAULT_TRANSITION
 								obj.content.transition.duration = v
 								onSave(obj)
 							}}
 							allowUndefined={false}
+							allowNull={false}
 						/>
 					</div>
 

--- a/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/vMix.tsx
+++ b/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/vMix.tsx
@@ -10,6 +10,7 @@ import {
 	VMixTransitionType,
 } from 'timeline-state-resolver-types'
 import { BooleanInput } from '../../../inputs/BooleanInput'
+import { DurationInput } from '../../../inputs/DurationInput'
 import { IntInput } from '../../../inputs/IntInput'
 import { SelectEnum } from '../../../inputs/SelectEnum'
 import { TextInput } from '../../../inputs/TextInput'
@@ -464,7 +465,7 @@ export const EditTimelineObjVMixAny: React.FC<{ obj: TimelineObjVMixAny; onSave:
 				</div>
 
 				<div className="setting">
-					<IntInput
+					<DurationInput
 						label="Transition Duration"
 						fullWidth
 						currentValue={obj.content.transition?.duration ?? 0}
@@ -480,6 +481,8 @@ export const EditTimelineObjVMixAny: React.FC<{ obj: TimelineObjVMixAny; onSave:
 							onSave(obj)
 						}}
 						allowUndefined={false}
+						allowNull={false}
+						defaultValue={0}
 					/>
 				</div>
 			</>

--- a/apps/app/src/react/styles/layer.scss
+++ b/apps/app/src/react/styles/layer.scss
@@ -39,7 +39,7 @@
 			&.selectable {
 				cursor: pointer;
 				&:hover {
-					opacity: 0.8;
+					filter: brightness(80%);
 				}
 			}
 			&.selected {
@@ -73,6 +73,8 @@
 				top: 0;
 				height: 100%;
 				width: 1em;
+
+				pointer-events: none;
 
 				&.transition--in {
 					left: 0;

--- a/apps/app/src/react/styles/layer.scss
+++ b/apps/app/src/react/styles/layer.scss
@@ -33,7 +33,7 @@
 			transition: $default-transition;
 			border-radius: $borderRadius;
 			justify-content: space-between;
-			overflow: hidden;
+			// overflow: hidden;
 			min-width: calc($timelineObjHandleWidth * 2);
 
 			&.selectable {
@@ -67,47 +67,75 @@
 				background: $invalidLayerColor !important;
 			}
 
+			.transition {
+				z-index: 1;
+				position: absolute;
+				top: 0;
+				height: 100%;
+				width: 1em;
+
+				&.transition--in {
+					left: 0;
+					background: linear-gradient(to bottom right, #000 49%, rgba(255, 255, 255, 0.3) 50%);
+				}
+				&.transition--out {
+					left: 100%;
+					background: linear-gradient(to top right, rgba(255, 255, 255, 0.3) 49%, rgba(0, 0, 0, 0.5) 50%);
+
+					&.at-end {
+						// There is no space to use to the right.
+						// Show that there is an out-transition in another way:
+						left: calc(100% - 5px);
+						border-left: 2px solid rgba(255, 255, 255, 0.5);
+						background: linear-gradient(to top right, rgba(255, 255, 255, 0.5) 49%, #000 50%);
+						width: 7px !important;
+					}
+				}
+			}
+
 			.body {
+				z-index: 2;
+
 				flex-grow: 1;
 				flex-shrink: 1;
 				min-width: 0;
 				display: flex;
-			}
+				.warning-icon {
+					margin-right: 0.6rem;
+					transform: translateY(2px);
+					flex-shrink: 0;
+				}
 
-			.warning-icon {
-				margin-right: 0.6rem;
-				transform: translateY(2px);
-				flex-shrink: 0;
-			}
+				.title,
+				.duration {
+					font-size: 1.4rem;
+					text-shadow: 0 0 4px #00000080;
+					white-space: nowrap;
+				}
 
-			.title,
-			.duration {
-				font-size: 1.4rem;
-				text-shadow: 0 0 4px #00000080;
-				white-space: nowrap;
-			}
+				.title {
+					font-weight: 600;
+					flex-shrink: 1;
+					min-width: 0;
+					overflow: hidden;
+					text-overflow: ellipsis;
+					margin-right: auto;
+				}
 
-			.title {
-				font-weight: 600;
-				flex-shrink: 1;
-				min-width: 0;
-				overflow: hidden;
-				text-overflow: ellipsis;
-				margin-right: auto;
-			}
-
-			.duration {
-				font-family: 'Barlow Condensed';
-				font-variant-numeric: tabular-nums;
-				font-weight: 500;
-				color: rgba(255, 255, 255, 0.7);
-				flex-shrink: 0;
-				margin-left: 1rem;
-				overflow: hidden;
-				text-overflow: ellipsis;
+				.duration {
+					font-family: 'Barlow Condensed';
+					font-variant-numeric: tabular-nums;
+					font-weight: 500;
+					color: rgba(255, 255, 255, 0.7);
+					flex-shrink: 0;
+					margin-left: 1rem;
+					overflow: hidden;
+					text-overflow: ellipsis;
+				}
 			}
 
 			.handle {
+				z-index: 3;
 				position: absolute;
 				top: 0;
 				height: 100%;

--- a/apps/app/src/react/styles/settings.scss
+++ b/apps/app/src/react/styles/settings.scss
@@ -10,3 +10,15 @@
 		}
 	}
 }
+
+.side-bar {
+	.settings {
+		.setting-separator {
+			height: 1em;
+		}
+		.settings-group {
+			padding: 0.5em 0 0.5em 0.5em;
+			border-left: 2px solid rgba(255, 255, 255, 0.25);
+		}
+	}
+}


### PR DESCRIPTION
closes #37 

This PR adds support for CasparCG transitions to the GUI.

TODO:

- [x] Testing
- [x] Review and improve display of transitions in the timeline-view

![image](https://user-images.githubusercontent.com/15196563/186190713-66e548f5-4940-4e08-b508-15b866dd9b7e.png)
