### PR TITLE
fix: blur current selection on Escape

### DIFF
--- a/apps/app/src/react/App.tsx
+++ b/apps/app/src/react/App.tsx
@@ -343,6 +343,7 @@ export const App = observer(function App() {
 			return
 		}
 
+		// Bind Escape key to clear any selected Groups, Parts or Timeline-objects:
 		const onEscapeKey = (e: KeyboardEvent) => {
 			try {
 				if (!currentRundownId) return
@@ -365,14 +366,12 @@ export const App = observer(function App() {
 				handleError(error)
 			}
 		}
-
 		sorensen.bind('Escape', onEscapeKey, {
 			up: false,
 			global: true,
 			exclusive: true,
 			preventDefaultPartials: false,
 		})
-
 		return () => {
 			sorensen.unbind('Escape', onEscapeKey)
 		}

--- a/apps/app/src/react/App.tsx
+++ b/apps/app/src/react/App.tsx
@@ -338,6 +338,46 @@ export const App = observer(function App() {
 		}
 	}, [sorensenInitialized, handleError, gui, currentRundownId, deleteSelectedTimelineObjs])
 
+	useEffect(() => {
+		if (!sorensenInitialized) {
+			return
+		}
+
+		const onEscapeKey = (e: KeyboardEvent) => {
+			try {
+				if (!currentRundownId) return
+				if (
+					document.activeElement?.tagName === 'INPUT' ||
+					document.activeElement?.classList.contains('MuiPaper-root') ||
+					document.activeElement?.classList.contains('MuiDialog-container') ||
+					document.activeElement?.classList.contains('MuiMenuItem-root')
+				)
+					return
+
+				e.preventDefault()
+
+				if (gui.selected.length === 0) {
+					// do nothing
+				} else if (gui.selected.length > 0) {
+					gui.clearSelected()
+				}
+			} catch (error) {
+				handleError(error)
+			}
+		}
+
+		sorensen.bind('Escape', onEscapeKey, {
+			up: false,
+			global: true,
+			exclusive: true,
+			preventDefaultPartials: false,
+		})
+
+		return () => {
+			sorensen.unbind('Escape', onEscapeKey)
+		}
+	}, [sorensenInitialized, handleError, gui, currentRundownId])
+
 	useMemoComputedValue(() => {
 		if (!project) return
 


### PR DESCRIPTION
This PR adds a window-wide hotkey for Escape to clear the current selection, if no input is selected and no pop-over/dialog open.