### PR TITLE
Feat: Add Error Reporting & User Agreement

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -85,6 +85,7 @@
 		"file-loader": "^6.2.0",
 		"formik": "^2.2.9",
 		"formik-mui": "^4.0.0-alpha.3",
+		"got": "^11.8.2",
 		"lodash": "^4.17.21",
 		"mobx": "^6.4.2",
 		"mobx-react-lite": "^3.3.0",

--- a/apps/app/src/electron/IPCServer.ts
+++ b/apps/app/src/electron/IPCServer.ts
@@ -126,7 +126,7 @@ export class IPCServer
 			if (methodName[0] !== '_') {
 				const fcn = (this as any)[methodName].bind(this)
 				if (fcn) {
-					ipcMain.handle(methodName, async (event, args0: string) => {
+					ipcMain.handle(methodName, async (event, args0: string[]) => {
 						try {
 							const args = unReplaceUndefined(args0)
 							const result = await fcn(...args)

--- a/apps/app/src/electron/IPCServer.ts
+++ b/apps/app/src/electron/IPCServer.ts
@@ -117,6 +117,7 @@ export class IPCServer
 			setKeyboardKeys: (activeKeys: ActiveTrigger[]) => void
 			makeDevData: () => Promise<void>
 			triggerHandleAutoFill: () => void
+			userHasAgreed: () => void
 		}
 	) {
 		super()
@@ -252,6 +253,15 @@ export class IPCServer
 		const appData = this.storage.getAppData()
 		appData.version.seenVersion = appData.version.currentVersion
 		this.storage.updateAppData(appData)
+	}
+	async acknowledgeUserAgreement(agreementVersion: string): Promise<void> {
+		const appData = this.storage.getAppData()
+		appData.userAgreement = agreementVersion
+
+		this.storage.updateAppData(appData)
+		if (agreementVersion) {
+			this.callbacks.userHasAgreed()
+		}
 	}
 	async playPart(arg: { rundownId: string; groupId: string; partId: string }): Promise<void> {
 		const now = Date.now()

--- a/apps/app/src/electron/IPCServer.ts
+++ b/apps/app/src/electron/IPCServer.ts
@@ -117,7 +117,7 @@ export class IPCServer
 			setKeyboardKeys: (activeKeys: ActiveTrigger[]) => void
 			makeDevData: () => Promise<void>
 			triggerHandleAutoFill: () => void
-			userHasAgreed: () => void
+			onAgreeToUserAgreement: () => void
 			handleError: (error: string, stack?: string) => void
 		}
 	) {
@@ -287,7 +287,7 @@ export class IPCServer
 
 		this.storage.updateAppData(appData)
 		if (agreementVersion) {
-			this.callbacks.userHasAgreed()
+			this.callbacks.onAgreeToUserAgreement()
 		}
 	}
 	async playPart(arg: { rundownId: string; groupId: string; partId: string }): Promise<void> {

--- a/apps/app/src/electron/IPCServer.ts
+++ b/apps/app/src/electron/IPCServer.ts
@@ -243,6 +243,25 @@ export class IPCServer
 		// Handle an error thrown in the client
 		this.callbacks.handleError(error, stack)
 	}
+	async debugThrowError(type: 'sync' | 'async' | 'setTimeout'): Promise<void> {
+		// This method is used for development-purposes only, to check how error reporting works.
+
+		if (type === 'sync') {
+			throw new Error('This is an error in an IPC method')
+		} else if (type === 'async') {
+			await new Promise((_, reject) => {
+				setTimeout(() => {
+					reject(new Error('This is an error in a promise'))
+				}, 10)
+			})
+		} else if (type === 'setTimeout') {
+			setTimeout(() => {
+				throw new Error('This is an error in a setTImeout')
+			}, 10)
+		} else {
+			assertNever(type)
+		}
+	}
 	async triggerSendAll(): Promise<void> {
 		this.storage.triggerEmitAll()
 		this.session.triggerEmitAll()

--- a/apps/app/src/electron/IPCServer.ts
+++ b/apps/app/src/electron/IPCServer.ts
@@ -118,6 +118,7 @@ export class IPCServer
 			makeDevData: () => Promise<void>
 			triggerHandleAutoFill: () => void
 			userHasAgreed: () => void
+			handleError: (error: string, stack?: string) => void
 		}
 	) {
 		super()
@@ -151,7 +152,10 @@ export class IPCServer
 								return result
 							}
 						} catch (error) {
-							this._log.error(`Error when calling ${methodName}:`, error)
+							this.callbacks.handleError(
+								`Error when calling ${methodName}: ${error}`,
+								typeof error === 'object' && (error as any).stack
+							)
 							throw error
 						}
 					})
@@ -234,6 +238,10 @@ export class IPCServer
 
 	async log(method: LogLevel, ...args: any[]): Promise<void> {
 		this._renderLog[method](args[0], ...args.slice(1))
+	}
+	async handleClientError(error: string, stack?: string): Promise<void> {
+		// Handle an error thrown in the client
+		this.callbacks.handleError(error, stack)
 	}
 	async triggerSendAll(): Promise<void> {
 		this.storage.triggerEmitAll()

--- a/apps/app/src/electron/SuperConductor.ts
+++ b/apps/app/src/electron/SuperConductor.ts
@@ -385,8 +385,10 @@ export class SuperConductor {
 			makeDevData: async () => {
 				await this.storage.makeDevData()
 			},
-			userHasAgreed: () => {
+			onAgreeToUserAgreement: () => {
 				this.telemetryHandler.setUserHasAgreed()
+				this.telemetryHandler.onAcceptUserAgreement()
+
 				if (!this.hasStoredStartupUserStatistics) {
 					this.hasStoredStartupUserStatistics = true
 					this.telemetryHandler.onStartup()

--- a/apps/app/src/electron/SuperConductor.ts
+++ b/apps/app/src/electron/SuperConductor.ts
@@ -35,7 +35,7 @@ export class SuperConductor {
 
 	session: SessionHandler
 	storage: StorageHandler
-	statisticsHandler: TelemetryHandler
+	telemetryHandler: TelemetryHandler
 	triggers?: TriggersHandler
 	bridgeHandler?: BridgeHandler
 
@@ -64,7 +64,7 @@ export class SuperConductor {
 			},
 			CURRENT_VERSION
 		)
-		this.statisticsHandler = new TelemetryHandler(this.storage)
+		this.telemetryHandler = new TelemetryHandler(this.log, this.storage)
 
 		this.session.on('bridgeStatus', (id: string, status: BridgeStatus | null) => {
 			this.ipcClient?.updateBridgeStatus(id, status)
@@ -103,18 +103,18 @@ export class SuperConductor {
 		for (const argv of process.argv) {
 			if (argv === '--disable-telemetry') {
 				console.log('Telemetry disabled')
-				this.statisticsHandler.disableTelemetry()
+				this.telemetryHandler.disableTelemetry()
 			}
 		}
 
 		const appData = this.storage.getAppData()
 		if (appData.userAgreement === USER_AGREEMENT_VERSION) {
 			// The user has previously agreed to the user agreement
-			this.statisticsHandler.setUserHasAgreed()
+			this.telemetryHandler.setUserHasAgreed()
 
 			if (!this.hasStoredStartupUserStatistics) {
 				this.hasStoredStartupUserStatistics = true
-				this.statisticsHandler.onStartup()
+				this.telemetryHandler.onStartup()
 			}
 		}
 	}
@@ -372,10 +372,10 @@ export class SuperConductor {
 				await this.storage.makeDevData()
 			},
 			userHasAgreed: () => {
-				this.statisticsHandler.setUserHasAgreed()
+				this.telemetryHandler.setUserHasAgreed()
 				if (!this.hasStoredStartupUserStatistics) {
 					this.hasStoredStartupUserStatistics = true
-					this.statisticsHandler.onStartup()
+					this.telemetryHandler.onStartup()
 				}
 			},
 		})

--- a/apps/app/src/electron/storageHandler.ts
+++ b/apps/app/src/electron/storageHandler.ts
@@ -14,6 +14,8 @@ import { makeDevData } from './makeDevData'
 import { getPartLabel } from '../lib/util'
 
 const fsWriteFile = fs.promises.writeFile
+const fsAppendFile = fs.promises.appendFile
+const fsReadFile = fs.promises.readFile
 const fsRm = fs.promises.rm
 const fsAccess = fs.promises.access
 const fsExists = async (filePath: string): Promise<boolean> => {
@@ -418,6 +420,24 @@ export class StorageHandler extends EventEmitter {
 		for (const resource of devData.resources) {
 			this.updateResource(resource.id, resource)
 		}
+	}
+
+	/** Add an telemetry entry */
+	async addTelemetryReport(data: any): Promise<void> {
+		await fsAppendFile(this.telemetryPath, JSON.stringify(data) + '\n', 'utf-8')
+	}
+	/** Overwrite telemetry entries */
+	async setTelemetryReport(strs: string[]): Promise<void> {
+		await fsWriteFile(this.telemetryPath, strs.join('\n') + '\n', 'utf-8')
+	}
+	async retrieveTelemetryReports(): Promise<string[]> {
+		if (!(await fsExists(this.telemetryPath))) return []
+		const str = await fsReadFile(this.telemetryPath, 'utf-8')
+		return str.split('\n')
+	}
+	async clearTelemetryReport(): Promise<void> {
+		if (!(await fsExists(this.telemetryPath))) return
+		await fsUnlink(this.telemetryPath)
 	}
 
 	/** Triggered when the stored data has been updated */
@@ -892,6 +912,9 @@ export class StorageHandler extends EventEmitter {
 	}
 	private get appDataPath(): string {
 		return path.join(this._baseFolder, 'appData.json')
+	}
+	private get telemetryPath() {
+		return path.join(this._baseFolder, 'telemetry.txt')
 	}
 	private get _projectsFolder() {
 		return path.join(this._baseFolder, 'Projects')

--- a/apps/app/src/electron/telemetry.ts
+++ b/apps/app/src/electron/telemetry.ts
@@ -1,0 +1,156 @@
+import got from 'got'
+import os from 'os'
+import { app } from 'electron'
+import { CURRENT_VERSION } from './bridgeHandler'
+import { StorageHandler } from './storageHandler'
+import { hash } from '../lib/util'
+
+/*
+  This file handles the sending of usage statistics.
+
+
+*/
+
+export class TelemetryHandler {
+	private userHasAgreed = false
+	private _disableTelemetry = false
+
+	private storedErrors = new Set<string>()
+
+	constructor(private storageHandler: StorageHandler) {}
+
+	private get enabled(): boolean {
+		return (
+			// User has agreed to the user agreement:
+			this.userHasAgreed &&
+			// Telemetry is not disabled:
+			!this._disableTelemetry &&
+			// Don't send updates when in development mode:
+			!app.isPackaged
+		)
+	}
+	/** This is called when the user has agreed to the user agreement */
+	setUserHasAgreed() {
+		this.userHasAgreed = true
+
+		this.triggerSendTelemetry()
+	}
+	disableTelemetry() {
+		this._disableTelemetry = true
+	}
+
+	/**
+	 * Create a report of usage statistics on application startup
+	 */
+	onStartup(): void {
+		const date = new Date()
+
+		this.storeTelemetry({
+			reportType: 'application-start',
+			date: `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`, // YYYY-MM-DD
+			version: CURRENT_VERSION,
+
+			osType: os.type(), // Which Operating system, eg "Windows_NT"
+			osRelease: os.release(), // Which OS version, eg "10.0.14393"
+			osPlatform: os.platform(), // Which OS platform, eg "win32"
+		})
+	}
+
+	onError(error: Error): void {
+		const date = new Date()
+
+		// Make sure we only store a certain error once, to avoid flooding:
+		const errorHash = hash(error.toString())
+		if (!this.storedErrors.has(errorHash)) {
+			this.storedErrors.add(errorHash)
+
+			this.storeTelemetry({
+				reportType: 'application-error',
+				date: `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`, // YYYY-MM-DD
+				version: CURRENT_VERSION,
+
+				osType: os.type(), // Which Operating system, eg "Windows_NT"
+				osRelease: os.release(), // Which OS version, eg "10.0.14393"
+				osPlatform: os.platform(), // Which OS platform, eg "win32"
+
+				error: error.toString(),
+				errorStack: error.stack,
+			})
+		}
+	}
+
+	/** Store a statistics report for later send */
+	private storeTelemetry(report: any): void {
+		if (!this.enabled) return // Don't do anything if the user hasn't agreed
+		this.storageHandler.addTelemetryReport(report).catch(console.error)
+	}
+
+	/**
+	 * Retrieve stored statistics and send them:
+	 */
+	private async sendTelemetry(): Promise<void> {
+		if (!this.enabled) return
+
+		const reports = await this.storageHandler.retrieveTelemetryReports()
+
+		const notSentStatistics: string[] = []
+		let errorCount = 0
+		for (const report of reports) {
+			if (!report) continue
+			try {
+				JSON.parse(report)
+			} catch (err) {
+				// if it's not parseable, don't send it
+				continue
+			}
+
+			// If there are errors, don't flood with requests:
+			if (errorCount < 3) {
+				try {
+					await got
+						// .post('http://superconductor-statistics/superconductor/reportUsageStatistics', {
+						// .post('http://localhost:2500/superconductor/reportUsageStatistics', {
+						.post(
+							// 'https://faas-ams3-2a2df116.doserverless.co/api/v1/web/fn-7ba9c1fc-f987-4993-b324-a86c98928fcb/telemetry/insert',
+							'https://faas-ams3-2a2df116.doserverless.co/api/v1/web/fn-7ba9c1fc-f987-4993-b324-a86c98928fcb/telemetry/insert',
+							{
+								json: {
+									report: report,
+								},
+							}
+						)
+						.json()
+				} catch (error: any) {
+					// For a strange reason we get an error even though it all works
+
+					if (!`${error.response?.body}`.match(/Incomplete web action path/)) {
+						// There was an error when reporting, put it back to the queue to be sent later:
+						notSentStatistics.push(report)
+						errorCount++
+
+						if (error.response) console.error(error.response?.body)
+						else console.error(error)
+					}
+				}
+			} else {
+				notSentStatistics.push(report)
+			}
+		}
+
+		if (notSentStatistics.length > 0) {
+			await this.storageHandler.setTelemetryReport(notSentStatistics)
+		} else {
+			await this.storageHandler.clearTelemetryReport()
+		}
+	}
+
+	private sendUsageStatisticsTimeout: NodeJS.Timer | undefined = undefined
+	private triggerSendTelemetry() {
+		if (!this.enabled) return
+		if (!this.sendUsageStatisticsTimeout) {
+			this.sendUsageStatisticsTimeout = setTimeout(() => {
+				this.sendTelemetry().catch(console.error)
+			}, 1000)
+		}
+	}
+}

--- a/apps/app/src/electron/telemetry.ts
+++ b/apps/app/src/electron/telemetry.ts
@@ -67,6 +67,15 @@ export class TelemetryHandler {
 		if (!this.storedErrors.has(errorHash)) {
 			this.storedErrors.add(errorHash)
 
+			if (stack) {
+				// Remove everything before "app.asar", as that can contain information about the local file system:
+				// Tested on data:
+				// "   at hashCode (C:\\Users\\USERNAME\\AppData\\Local\\Programs\\superconductor\\resources\\app.asar\\dist\\lib\\util.js:209:26)"
+				// "   at Generator.next (<anonymous>)"
+				// "   at (C:\\Users\\USERNAME\\AppData\\Local\\Programs\\superconductor\\resources\\app.asar\\dist\\lib\\util.js:209:26)"
+				stack = stack.replace(/^(\W+at )(\w+)?.+(app\.asar)/gm, '$1$2 LOCAL_PATH')
+			}
+
 			this.storeTelemetry({
 				reportType: 'application-error',
 				error: error,

--- a/apps/app/src/ipc/IPCAPI.ts
+++ b/apps/app/src/ipc/IPCAPI.ts
@@ -71,6 +71,7 @@ export interface IPCServerMethods {
 	makeDevData(): void
 
 	acknowledgeSeenVersion: () => void
+	acknowledgeUserAgreement: (agreementVersion: string) => void
 	playPart: (arg: { rundownId: string; groupId: string; partId: string; resume?: boolean }) => void
 	pausePart: (arg: { rundownId: string; groupId: string; partId: string; pauseTime?: number }) => void
 	stopPart: (arg: { rundownId: string; groupId: string; partId: string }) => void

--- a/apps/app/src/ipc/IPCAPI.ts
+++ b/apps/app/src/ipc/IPCAPI.ts
@@ -66,6 +66,7 @@ export interface Action {
 export interface IPCServerMethods {
 	log: (method: LogLevel, ...args: any[]) => void
 	handleClientError: (error: string, stack?: string) => void
+	debugThrowError: (type: 'sync' | 'async' | 'setTimeout') => void
 	triggerSendAll: () => void
 	triggerSendRundown: (arg: { rundownId: string }) => void
 	setKeyboardKeys(arg: { activeKeys: ActiveTrigger[] }): void

--- a/apps/app/src/ipc/IPCAPI.ts
+++ b/apps/app/src/ipc/IPCAPI.ts
@@ -65,6 +65,7 @@ export interface Action {
 /** Methods that can be called on the server, by the client */
 export interface IPCServerMethods {
 	log: (method: LogLevel, ...args: any[]) => void
+	handleClientError: (error: string, stack?: string) => void
 	triggerSendAll: () => void
 	triggerSendRundown: (arg: { rundownId: string }) => void
 	setKeyboardKeys(arg: { activeKeys: ActiveTrigger[] }): void

--- a/apps/app/src/lib/userAgreement.ts
+++ b/apps/app/src/lib/userAgreement.ts
@@ -1,0 +1,1 @@
+export const USER_AGREEMENT_VERSION = '1'

--- a/apps/app/src/models/App/AppData.ts
+++ b/apps/app/src/models/App/AppData.ts
@@ -6,6 +6,8 @@ export interface AppData {
 		/** The version of the SuperConductor who saved the data*/
 		currentVersion: string
 	}
+	/** Which version of the user agreement the user has agreed to  */
+	userAgreement?: string
 	project: {
 		id: string
 	}

--- a/apps/app/src/react/App.tsx
+++ b/apps/app/src/react/App.tsx
@@ -109,8 +109,6 @@ export const App = observer(function App() {
 
 	const handleError = useCallback(
 		(error: any) => {
-			// console.log('Recreate handleError')
-			// return (error: any): void => {
 			logger.error(error)
 
 			let message: string
@@ -120,7 +118,7 @@ export const App = observer(function App() {
 			} else if (error === null) {
 				message = ''
 			} else if (typeof error === 'object' && 'message' in error) {
-				message = (error as any).message ?? ''
+				message = error.message ?? ''
 			} else if (typeof error === 'object' && typeof error.reason === 'object' && error.reason.message) {
 				message = error.reason.message
 				stack = error.reason.stack || error.reason.reason

--- a/apps/app/src/react/api/IPCServer.ts
+++ b/apps/app/src/react/api/IPCServer.ts
@@ -26,6 +26,9 @@ export class IPCServer implements Promisify<IPCServerMethods> {
 	handleClientError(...args: ServerArgs<'handleClientError'>) {
 		return this.invokeServerMethod('handleClientError', ...args)
 	}
+	debugThrowError(...args: ServerArgs<'debugThrowError'>) {
+		return this.invokeServerMethod('debugThrowError', ...args)
+	}
 	triggerSendAll(...args: ServerArgs<'triggerSendAll'>) {
 		return this.invokeServerMethod('triggerSendAll', ...args)
 	}

--- a/apps/app/src/react/api/IPCServer.ts
+++ b/apps/app/src/react/api/IPCServer.ts
@@ -40,6 +40,9 @@ export class IPCServer implements Promisify<IPCServerMethods> {
 	acknowledgeSeenVersion(...args: ServerArgs<'acknowledgeSeenVersion'>) {
 		return this.invokeServerMethod('acknowledgeSeenVersion', ...args)
 	}
+	acknowledgeUserAgreement(...args: ServerArgs<'acknowledgeUserAgreement'>) {
+		return this.invokeServerMethod('acknowledgeUserAgreement', ...args)
+	}
 	playPart(...args: ServerArgs<'playPart'>) {
 		return this.invokeServerMethod('playPart', ...args)
 	}

--- a/apps/app/src/react/api/IPCServer.ts
+++ b/apps/app/src/react/api/IPCServer.ts
@@ -23,6 +23,9 @@ export class IPCServer implements Promisify<IPCServerMethods> {
 	log(...args: ServerArgs<'log'>) {
 		return this.invokeServerMethod('log', ...args)
 	}
+	handleClientError(...args: ServerArgs<'handleClientError'>) {
+		return this.invokeServerMethod('handleClientError', ...args)
+	}
 	triggerSendAll(...args: ServerArgs<'triggerSendAll'>) {
 		return this.invokeServerMethod('triggerSendAll', ...args)
 	}

--- a/apps/app/src/react/components/UserAgreementScreen.tsx
+++ b/apps/app/src/react/components/UserAgreementScreen.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { Button, Dialog, DialogContent, DialogActions, Typography } from '@mui/material'
+import { styled } from '@mui/material/styles'
+import { USER_AGREEMENT_VERSION } from '../../lib/userAgreement'
+
+/**
+ * The User Agreement is shown to users on startup
+ * Note: If any changes are made to the user agreement, USER_AGREEMENT_VERSION must be incremeneted so that it's shown to users again
+ */
+
+export const UserAgreementScreen: React.FC<{
+	onAgree: (agreementVersion: string) => void
+	onDisagree: () => void
+}> = ({ onAgree, onDisagree }) => {
+	return (
+		<BootstrapDialog aria-labelledby="customized-dialog-title" open={true}>
+			<DialogContent dividers>
+				<Typography gutterBottom>
+					<b>SuperConductor user agreement</b>
+					<br />
+					<br />
+					<b>By using this software you agree to this user agreement:</b>
+					<br />
+					<br />
+					<b>This is a pre-release software</b>, features will be added and <i>might be removed</i> in later
+					versions. It is <b>free to use</b>, although we (SuperFly.tv) reserve the right to possibly
+					introduce a paid version in the future, to ensure further development and maintenance.
+					<br />
+					<br />
+					<b>Crash/Error reporting and statistics</b>
+					<br />
+					SuperConductor sends crash/error reports and the Operating System version upon startup, to
+					SuperFly.tv. This helps us understand how the application is used and helps us with planning for
+					future features.
+					<br />
+					The sent data is anonymous, and you can see exactly what data is sent in{' '}
+					<a
+						href="https://github.com/SuperFlyTV/SuperConductor/blob/master/apps/app/src/electron/telemetry.ts"
+						target="_blank"
+						rel="noreferrer"
+					>
+						the source code here
+					</a>
+					.<br />
+					<br />
+				</Typography>
+
+				<Typography gutterBottom>
+					<b>LICENSE</b>
+					<br />
+					<br />
+					This program is free software: you can redistribute it and/or modify it under the terms of the GNU
+					Affero General Public License as published by the Free Software Foundation, either version 3 of the
+					License, or (at your option) any later version. This program is distributed in the hope that it will
+					be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+					FOR A PARTICULAR PURPOSE. See the{' '}
+					<a
+						href="https://github.com/SuperFlyTV/SuperConductor/blob/master/COPYING"
+						target="_blank"
+						rel="noreferrer"
+					>
+						GNU Affero General Public License
+					</a>{' '}
+					for more details.
+				</Typography>
+			</DialogContent>
+			<DialogActions>
+				<Button autoFocus onClick={() => onDisagree()}>
+					No, close the application
+				</Button>
+				<Button autoFocus onClick={() => onAgree(USER_AGREEMENT_VERSION)}>
+					I accept the User Agreement
+				</Button>
+			</DialogActions>
+		</BootstrapDialog>
+	)
+}
+
+const BootstrapDialog = styled(Dialog)(({ theme }) => ({
+	'& .MuiDialogContent-root': {
+		padding: theme.spacing(2),
+	},
+	'& .MuiDialogActions-root': {
+		padding: theme.spacing(1),
+	},
+}))

--- a/apps/app/src/react/components/UserAgreementScreen.tsx
+++ b/apps/app/src/react/components/UserAgreementScreen.tsx
@@ -16,10 +16,10 @@ export const UserAgreementScreen: React.FC<{
 		<BootstrapDialog aria-labelledby="customized-dialog-title" open={true}>
 			<DialogContent dividers>
 				<Typography gutterBottom>
-					<b>SuperConductor user agreement</b>
+					<b>SuperConductor User Agreement</b>
 					<br />
 					<br />
-					<b>By using this software you agree to this user agreement:</b>
+					<b>By using this software you agree to this User Agreement:</b>
 					<br />
 					<br />
 					<b>This is a pre-release software</b>, features will be added and <i>might be removed</i> in later

--- a/apps/app/src/react/components/util/Debug.tsx
+++ b/apps/app/src/react/components/util/Debug.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react'
+
+export function DebugTestErrors() {
+	const els: JSX.Element[] = []
+
+	for (let i = 0; i < 10; i++) {
+		// These elements are missing a "key"-prop, which should trigger a React warning
+		els.push(<div>A</div>)
+	}
+
+	const [wait, setWait] = useState(false)
+	useEffect(() => {
+		setTimeout(() => {
+			setWait(true)
+		}, 200)
+	}, [])
+
+	useEffect(() => {
+		if (wait) {
+			throw new Error('This is a client error thrown in a React component')
+		}
+	}, [wait])
+
+	return <>{els}</>
+}

--- a/apps/app/src/react/components/util/ErrorBoundary.tsx
+++ b/apps/app/src/react/components/util/ErrorBoundary.tsx
@@ -1,0 +1,199 @@
+import * as React from 'react'
+
+interface IState {
+	hasError: boolean
+	error?: Error
+	info?: React.ErrorInfo
+	expandedStack?: boolean
+	expandedComponentStack?: boolean
+}
+
+export class ErrorBoundary extends React.Component<unknown, IState> {
+	static style = {
+		box: {
+			display: 'block',
+			position: 'static',
+			margin: '0',
+			padding: '10px',
+			fontSize: '10px',
+			lineHeight: '1.2em',
+			fontFamily: 'Roboto, sans-serif',
+			fontWeight: 300,
+			width: '100%',
+			height: 'auto',
+			overflow: 'visible',
+			background: 'white',
+			textDecoration: 'none',
+			color: 'red',
+			border: '1px solid red',
+		} as React.CSSProperties,
+		header: {
+			display: 'block',
+			position: 'static',
+			margin: '0 0 10px 0',
+			padding: '0',
+			fontSize: '14px',
+			lineHeight: '1.2em',
+			fontFamily: 'Roboto, sans-serif',
+			fontWeight: 600,
+			width: '100%',
+			height: 'auto',
+			overflow: 'visible',
+			background: 'none',
+			textDecoration: 'none',
+			color: 'red',
+			border: 'none',
+		} as React.CSSProperties,
+		message: {
+			display: 'block',
+			position: 'static',
+			margin: '0 0 10px 0',
+			padding: '0',
+			fontSize: '10px',
+			lineHeight: '1.2em',
+			fontFamily: 'Roboto, sans-serif',
+			fontWeight: 300,
+			width: '100%',
+			height: 'auto',
+			overflow: 'visible',
+			background: 'white',
+			textDecoration: 'none',
+			color: 'red',
+			border: 'none',
+		} as React.CSSProperties,
+		stack: {
+			display: 'block',
+			position: 'static',
+			margin: '0 0 10px 0',
+			padding: '0',
+			fontSize: '10px',
+			lineHeight: '1.2em',
+			fontFamily: 'Roboto, sans-serif',
+			fontWeight: 300,
+			width: '100%',
+			height: 'auto',
+			overflow: 'hidden',
+			textOverflow: 'ellipsis',
+			background: 'none',
+			textDecoration: 'none',
+			color: 'red',
+			border: 'none',
+			cursor: 'pointer',
+			whiteSpace: 'nowrap',
+		} as React.CSSProperties,
+		componentStack: {
+			display: 'block',
+			position: 'static',
+			margin: '0 0 10px 0',
+			padding: '0',
+			fontSize: '10px',
+			lineHeight: '1.2em',
+			fontFamily: 'Roboto, sans-serif',
+			fontWeight: 300,
+			width: '100%',
+			height: 'auto',
+			overflow: 'hidden',
+			textOverflow: 'ellipsis',
+			background: 'none',
+			textDecoration: 'none',
+			color: 'red',
+			border: 'none',
+			cursor: 'pointer',
+			whiteSpace: 'nowrap',
+		} as React.CSSProperties,
+		expandedStack: {
+			whiteSpace: 'pre',
+		} as React.CSSProperties,
+		resetButton: {
+			display: 'block',
+			position: 'static',
+			margin: '0 0 0 0',
+			padding: '0',
+			fontSize: '10px',
+			lineHeight: '1.2em',
+			fontFamily: 'Roboto, sans-serif',
+			fontWeight: 600,
+			width: '100%',
+			height: 'auto',
+			overflow: 'visible',
+			background: 'white',
+			textDecoration: 'underline',
+			color: 'red',
+			border: 'none',
+			cursor: 'pointer',
+		} as React.CSSProperties,
+	}
+
+	constructor(props: any) {
+		super(props)
+		this.state = {
+			hasError: false,
+		}
+	}
+
+	componentDidCatch(error: Error, info: React.ErrorInfo) {
+		this.setState({
+			hasError: true,
+			error: error,
+			info: info,
+		})
+		// @ts-expect-error hack
+		if (window.handleError) {
+			// @ts-expect-error hack
+			window.handleError('React error: ' + error.message, `${error.stack} ${info.componentStack}`)
+		}
+	}
+
+	toggleComponentStack = () => {
+		this.setState({ expandedComponentStack: !this.state.expandedComponentStack })
+	}
+
+	toggleStack = () => {
+		this.setState({ expandedStack: !this.state.expandedStack })
+	}
+
+	resetComponent = () => {
+		this.setState({ hasError: false })
+	}
+
+	render() {
+		if (this.state.hasError) {
+			return (
+				<div style={ErrorBoundary.style.box}>
+					{this.state.error && (
+						<React.Fragment>
+							<h5 style={ErrorBoundary.style.header}>{this.state.error.name}</h5>
+							{this.state.info && (
+								<p
+									style={{
+										...ErrorBoundary.style.componentStack,
+										...(this.state.expandedComponentStack ? ErrorBoundary.style.expandedStack : {}),
+									}}
+									onClick={this.toggleComponentStack}
+								>
+									{this.state.info.componentStack}
+								</p>
+							)}
+							<p style={ErrorBoundary.style.message}>{this.state.error.message}</p>
+							{this.state.error.stack && (
+								<p
+									style={{
+										...ErrorBoundary.style.stack,
+										...(this.state.expandedStack ? ErrorBoundary.style.expandedStack : {}),
+									}}
+									onClick={this.toggleStack}
+								>
+									{this.state.error.stack}
+								</p>
+							)}
+						</React.Fragment>
+					)}
+					<div style={ErrorBoundary.style.resetButton} onClick={this.resetComponent}>
+						Try to restart component
+					</div>
+				</div>
+			)
+		}
+		return this.props.children || null
+	}
+}

--- a/apps/app/src/react/mobx/AppStore.ts
+++ b/apps/app/src/react/mobx/AppStore.ts
@@ -15,6 +15,8 @@ export class AppStore {
 		currentVersion: string
 	} = undefined
 
+	userAgreement?: string
+
 	bridgeStatuses: { [bridgeId: string]: BridgeStatus } = {}
 	peripherals: { [peripheralId: string]: PeripheralStatus } = {}
 
@@ -44,6 +46,7 @@ export class AppStore {
 	update(data: AppData) {
 		this.windowPosition = data.windowPosition
 		this.version = data.version
+		this.userAgreement = data.userAgreement
 	}
 
 	updateBridgeStatus(bridgeId: string, status: BridgeStatus | null) {


### PR DESCRIPTION
This PR adds two new things:

**Crash / Error Reporting and statistics**
SuperConductor will send reports to a SuperFly.tv-database upon startup and upon an error/crash. The reason for this is to catch and fix errors that happen out there in the wild.

If needed, it is possible to opt out by adding the `--disable-telemetry` CLI argument.

I've also made the code that handles receival of the data public [here](https://github.com/SuperFlyTV/superconductor-telemetry), if anyone's curious.


**User Agreement**
It is important that the user understands that the application sends usage reports. Therefore, I've added a User Agreement-splash screen that the user will have to accept in order to use the application.

![image](https://user-images.githubusercontent.com/15196563/188404620-12bb3065-06fe-4598-828e-9ed0eef0ee5b.png)
