### PR TITLE
fix: improve the readability of device statuses in the top header

### DIFF
--- a/apps/app/src/react/components/headerBar/deviceStatuses/ConnectionStatus.tsx
+++ b/apps/app/src/react/components/headerBar/deviceStatuses/ConnectionStatus.tsx
@@ -20,9 +20,11 @@ export const ConnectionStatus: React.FC<{
 			href={props.onClick ? '#' : undefined}
 			onClick={props.onClick}
 		>
-			{props.label}
+			<div className="connection-status__content">
+				<div className="connection-status__label">{props.label}</div>
 
-			<div className="connection-status__dot"></div>
+				<div className="connection-status__dot"></div>
+			</div>
 		</a>
 	)
 }

--- a/apps/app/src/react/components/pages/homePage/scList/style.scss
+++ b/apps/app/src/react/components/pages/homePage/scList/style.scss
@@ -1,3 +1,5 @@
+@import '../../../../styles/foundation/colors';
+
 .header-label {
 	&:not(:last-child) {
 		border-right: 0.2rem solid rgba(255, 255, 255, 0.3);
@@ -23,12 +25,12 @@
 .status-circle {
 	width: 0.8rem;
 	height: 0.8rem;
-	background: #c03f3f;
+	background: $deviceOfflineColor;
 	border-radius: 50%;
 	margin-right: 1.5rem;
 
 	&.connected {
-		background: #5bc780;
+		background: $deviceOnlineColor;
 	}
 }
 

--- a/apps/app/src/react/styles/connection-status.scss
+++ b/apps/app/src/react/styles/connection-status.scss
@@ -1,10 +1,24 @@
 .connection-status {
 	display: flex;
+	justify-content: center;
 	align-items: center;
 	padding: 0 0.5rem;
 	color: $deviceOfflineColor;
 	font-size: 1.2rem;
 	text-decoration: none;
+
+	&__content {
+		display: flex;
+		align-items: center;
+		border-radius: 50px;
+		background-color: rgba(0, 0, 0, 0.75);
+		padding: 0 0.5rem;
+	}
+
+	&__label {
+		position: relative;
+		top: -1px;
+	}
 
 	&__dot {
 		margin-left: 0.35rem;

--- a/apps/app/src/react/styles/foundation/_colors.scss
+++ b/apps/app/src/react/styles/foundation/_colors.scss
@@ -59,8 +59,8 @@ $partMetaColor: #2d3340;
 
 $emptyLayerColor: #1b1e26;
 
-$deviceOfflineColor: #ff0000;
-$deviceOnlineColor: #148c00;
+$deviceOfflineColor: #ff5f5f;
+$deviceOnlineColor: #5bc780;
 
 $headerTabNormalBg: #505050;
 $headerTabHoverBg: #616161;


### PR DESCRIPTION
This PR makes the device statuses in the top header more readable by adding a pill-shaped dark background and lightening the text colors. This gives both the red and green colors a contrast ratio >= 7.0, making them meet WCAG AAA standards for legibility. This PR also unifies the colors used in the top header and on the Bridges page.

![image](https://user-images.githubusercontent.com/873012/195450802-e53a0694-4a9c-4d46-b44c-f218ecb50588.png)
![image](https://user-images.githubusercontent.com/873012/195450837-f48d6f15-db96-4225-9c0f-4df97c98abce.png)