### PR TITLE
fix: prevent invalid timelineobj changes

### DIFF
--- a/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/lib.tsx
+++ b/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/lib.tsx
@@ -1,6 +1,6 @@
 import { MenuItem, TextField } from '@mui/material'
 import React, { useContext } from 'react'
-import { sortMappings } from '../../../../../lib/TSRMappings'
+import { filterMapping, sortMappings } from '../../../../../lib/TSRMappings'
 import { TimelineEnable } from 'superfly-timeline'
 import { TSRTimelineObj } from 'timeline-state-resolver-types'
 import { ProjectContext } from '../../../../contexts/Project'
@@ -47,7 +47,7 @@ export const EditWrapper: React.FC<{
 						{project.mappings &&
 							sortMappings(project.mappings)
 								.filter(({ mapping }) => {
-									return mapping.device === obj.content.deviceType
+									return filterMapping(mapping, obj)
 								})
 								.map(({ layerId, mapping }) => (
 									<MenuItem key={layerId} value={layerId}>

--- a/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/lib.tsx
+++ b/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/lib.tsx
@@ -2,10 +2,9 @@ import { MenuItem, TextField } from '@mui/material'
 import React, { useContext } from 'react'
 import { sortMappings } from '../../../../../lib/TSRMappings'
 import { TimelineEnable } from 'superfly-timeline'
-import { DeviceType, TSRTimelineObj } from 'timeline-state-resolver-types'
+import { TSRTimelineObj } from 'timeline-state-resolver-types'
 import { ProjectContext } from '../../../../contexts/Project'
 import { DurationInput } from '../../../inputs/DurationInput'
-import { SelectEnum } from '../../../inputs/SelectEnum'
 import { TextInput } from '../../../inputs/TextInput'
 import { getMappingName } from '../../../../../lib/util'
 
@@ -31,17 +30,6 @@ export const EditWrapper: React.FC<{
 		<div className="edit-timeline-obj">
 			<div className="settings">
 				<div className="setting">
-					<SelectEnum
-						label={'Device Type'}
-						fullWidth
-						currentValue={obj.content.deviceType}
-						options={DeviceType}
-						onChange={(newValue) => {
-							obj.content.deviceType = newValue
-							onSave(obj)
-						}}
-					/>
-
 					<TextField
 						select
 						fullWidth


### PR DESCRIPTION
This PR makes two small changes to the timeline object inspector:

1. It removes the Device Type dropdown because it caused more bugs than it solved. Properly implementing this dropdown would require substantial effort and guesswork, so we're putting it aside for now.
2. It ensures that only valid layers are present in the Layer dropdown.