### PR TITLE
Fix: CasparCG template transitions

### DIFF
--- a/apps/app/src/lib/TimelineObj.ts
+++ b/apps/app/src/lib/TimelineObj.ts
@@ -287,6 +287,10 @@ export function modifyTimelineObjectForPlayout(
 					obj.content.data = parametersToCasparXML(data)
 				}
 			}
+			// Templates doesn't support Transitions, so we remove them.
+			// This is a temporary fix for a but in TSR and can be removed later.
+			// (the bug is that a template is stopped with a PLAY "empty" instead of a CG STOP )
+			delete obj.content.transitions
 		}
 	} else if (obj.content.deviceType === DeviceType.PHAROS) {
 		if (obj.content.type === TimelineContentTypePharos.TIMELINE) {

--- a/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/casparcg.tsx
+++ b/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/casparcg.tsx
@@ -636,9 +636,7 @@ export const EditTimelineObjCasparCGAny: React.FC<{ obj: TimelineObjCasparCGAny;
 
 				<CasparEditTemplateData obj={obj} onSave={onSave} />
 
-				{getSettingsTransitions(obj)}
-
-				{showAllButton}
+				{/* {showAllButton} */}
 			</>
 		)
 	} else if (obj.content.type === TimelineContentTypeCasparCg.HTMLPAGE) {


### PR DESCRIPTION
This removes the transitions from CasparCG Templates, since they aren't really supported by CasparCG anyway.

This also fixes an issue where when stopping a Template the wrong command is sent (a PLAY "empty" instead of a CG STOP).

closes #101 