### PR TITLE
feat: allow filtering per Resource Type

### DIFF
--- a/apps/app/src/lib/util.ts
+++ b/apps/app/src/lib/util.ts
@@ -619,6 +619,12 @@ export function getDeviceName(project: Project, deviceId: string) {
 export function getMappingName(mapping: Mapping, layerId: string): string {
 	return mapping.layerName ?? layerId
 }
+export function getResourceTypeName(resourceType: ResourceType): string {
+	if (!ResourceType[resourceType]) {
+		return 'Unknown type'
+	}
+	return ResourceType[resourceType] as string
+}
 /** Returns a number it the search is somewhere in source, for example "johny" matches "Johan Nyman", or null if it's not found */
 export function scatterMatchString(source: string, search: string): null | number {
 	search = search.toLowerCase()

--- a/apps/app/src/react/components/inputs/Btn/style.scss
+++ b/apps/app/src/react/components/inputs/Btn/style.scss
@@ -1,3 +1,5 @@
+@import './../../../styles/foundation/variables';
+
 .btn {
 	cursor: pointer;
 	display: inline-flex;
@@ -10,7 +12,7 @@
 	margin: 0;
 	vertical-align: middle;
 
-	font-family: Barlow, sans-serif;
+	font-family: $mainFont;
 	font-weight: 500;
 	font-size: 1.3rem;
 	line-height: 1.75;

--- a/apps/app/src/react/components/inputs/ToggleBtn/style.scss
+++ b/apps/app/src/react/components/inputs/ToggleBtn/style.scss
@@ -1,3 +1,5 @@
+@import './../../../styles/foundation/variables';
+
 .toggle-btn {
 	cursor: pointer;
 	display: inline-flex;
@@ -9,7 +11,7 @@
 	outline: 0;
 	margin: 0;
 
-	font-family: Barlow, sans-serif;
+	font-family: $mainFont;
 	font-weight: 500;
 	font-size: 1.3rem;
 	line-height: 1.75;

--- a/apps/app/src/react/components/sidebar/SidebarContent.tsx
+++ b/apps/app/src/react/components/sidebar/SidebarContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React from 'react'
 import classNames from 'classnames'
 
 export const SidebarContent: React.FC<{
@@ -6,33 +6,12 @@ export const SidebarContent: React.FC<{
 	className: string
 	children: React.ReactNode
 }> = (props) => {
-	const header = useRef<HTMLDivElement | null>()
-
-	const [headerHeight, setHeaderHeight] = React.useState<number | undefined>(undefined)
-
-	useEffect(() => {
-		if (header.current) {
-			const height = header.current.offsetHeight
-
-			setHeaderHeight(height)
-		}
-	}, [])
-
 	return (
 		<div className={classNames('sidebar', props.className)}>
-			<div
-				className="sidebar__header"
-				ref={(el) => {
-					header.current = el
-				}}
-			>
+			<div className="sidebar__header">
 				{typeof props.title === 'string' ? <span className="title">{props.title}</span> : props.title}
 			</div>
-			{headerHeight !== undefined && (
-				<div className="sidebar__content" style={{ top: headerHeight }}>
-					{props.children}
-				</div>
-			)}
+			<div className="sidebar__content">{props.children}</div>
 		</div>
 	)
 }

--- a/apps/app/src/react/components/sidebar/SidebarResourceLibrary.tsx
+++ b/apps/app/src/react/components/sidebar/SidebarResourceLibrary.tsx
@@ -17,7 +17,6 @@ import {
 	ListItemText,
 	MenuItem,
 	OutlinedInput,
-	TextField,
 	Typography,
 	Select,
 	SelectChangeEvent,
@@ -27,12 +26,14 @@ import {
 	AccordionSummary,
 	AccordionDetails,
 	Badge,
+	InputAdornment,
+	IconButton,
 } from '@mui/material'
 import { TextField as FormikMuiTextField } from 'formik-mui'
 import { ErrorHandlerContext } from '../../contexts/ErrorHandler'
 import { store } from '../../mobx/store'
 import { observer } from 'mobx-react-lite'
-import { HiRefresh, HiChevronDown } from 'react-icons/hi'
+import { HiRefresh, HiChevronDown, HiOutlineX } from 'react-icons/hi'
 import { useDebounce } from '../../lib/useDebounce'
 import { sortMappings } from '../../../lib/TSRMappings'
 import { useMemoComputedArray, useMemoComputedObject, useMemoComputedValue } from '../../mobx/lib'
@@ -158,6 +159,21 @@ export const SidebarResourceLibrary: React.FC = observer(function SidebarResourc
 		store.guiStore.updateResourceLibrary({
 			// On autofill we get a stringified value.
 			detailedFiltersExpanded: expanded,
+		})
+	}, [])
+
+	const handleClearNameFilter = useCallback(() => {
+		store.guiStore.updateResourceLibrary({
+			nameFilterValue: '',
+		})
+	}, [])
+
+	const handleClearDetailedFilter = useCallback((e: React.MouseEvent<HTMLElement>) => {
+		e.preventDefault()
+		e.stopPropagation()
+		store.guiStore.updateResourceLibrary({
+			deviceFilterValue: [],
+			resourceTypeFilterValue: [],
 		})
 	}, [])
 
@@ -312,6 +328,7 @@ export const SidebarResourceLibrary: React.FC = observer(function SidebarResourc
 		[deviceFilterValue, resourceTypeFilterValue]
 	)
 	const hasDetailedFilters = detailedFiltersCount > 0
+	const hasNameFilter = nameFilterValue !== ''
 
 	if (!currentRundownId) {
 		return null
@@ -360,22 +377,28 @@ export const SidebarResourceLibrary: React.FC = observer(function SidebarResourc
 				</div>
 			</div>
 
-			<TextField
-				size="small"
-				margin="normal"
-				fullWidth
-				label="Filter Resources by Name"
-				value={nameFilterValue}
-				InputProps={{
-					type: 'search',
-				}}
-				sx={{ mt: 0 }}
-				onChange={(event) => {
-					store.guiStore.updateResourceLibrary({
-						nameFilterValue: event.target.value,
-					})
-				}}
-			/>
+			<FormControl fullWidth size="small" sx={{ my: 1 }}>
+				<InputLabel htmlFor="resource-library-name-filter">Filter Resources by Name</InputLabel>
+				<OutlinedInput
+					id="resource-library-name-filter"
+					value={nameFilterValue}
+					onChange={(event) => {
+						store.guiStore.updateResourceLibrary({
+							nameFilterValue: event.target.value,
+						})
+					}}
+					endAdornment={
+						hasNameFilter && (
+							<InputAdornment position="end">
+								<IconButton aria-label="Clear name filter" edge="end" onClick={handleClearNameFilter}>
+									<HiOutlineX />
+								</IconButton>
+							</InputAdornment>
+						)
+					}
+					label="Filter Resources by Name"
+				/>
+			</FormControl>
 
 			<Accordion expanded={detailedFiltersExpanded} onChange={handleExpandDetailedFilter}>
 				<AccordionSummary expandIcon={<HiChevronDown />} aria-controls="panel1bh-content" id="panel1bh-header">
@@ -383,6 +406,16 @@ export const SidebarResourceLibrary: React.FC = observer(function SidebarResourc
 						<Badge badgeContent={detailedFiltersCount} color="primary" hidden={!hasDetailedFilters}>
 							Detailed filters
 						</Badge>
+						{detailedFiltersCount > 0 && (
+							<IconButton
+								aria-label="Clear detailed filters"
+								edge="end"
+								onClick={handleClearDetailedFilter}
+								sx={{ m: 0, p: 0, ml: 3 }}
+							>
+								<HiOutlineX />
+							</IconButton>
+						)}
 					</Typography>
 				</AccordionSummary>
 				<AccordionDetails>

--- a/apps/app/src/react/components/util/SmallCheckbox.tsx
+++ b/apps/app/src/react/components/util/SmallCheckbox.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Checkbox, CheckboxProps } from '@mui/material'
+
+export function SmallCheckbox(props: CheckboxProps) {
+	return <Checkbox sx={{ p: 0, pr: 1 }} size="small" {...props} />
+}

--- a/apps/app/src/react/mobx/GuiStore.ts
+++ b/apps/app/src/react/mobx/GuiStore.ts
@@ -59,6 +59,8 @@ interface ResourceLibrarySettings {
 	lastSelectedResourceId: string | null
 	nameFilterValue: string
 	deviceFilterValue: string[]
+	resourceTypeFilterValue: string[]
+	detailedFiltersExpanded: boolean
 }
 export class GuiStore {
 	serverAPI = new IPCServer(ipcRenderer)
@@ -70,6 +72,8 @@ export class GuiStore {
 		lastSelectedResourceId: null,
 		nameFilterValue: '',
 		deviceFilterValue: [],
+		resourceTypeFilterValue: [],
+		detailedFiltersExpanded: false,
 	}
 
 	definingArea: DefiningArea | null = null

--- a/apps/app/src/react/styles/foundation/_variables.scss
+++ b/apps/app/src/react/styles/foundation/_variables.scss
@@ -5,6 +5,8 @@
  */
 
 $mainFont: 'Barlow', sans-serif;
+$mainFontSemiCondensed: 'Barlow Semi Condensed', sans-serif;
+$mainFontCondensed: 'Barlow Condensed', sans-serif;
 $partTabWidth: 2.2rem;
 $partDragIndicatorSize: 8px;
 $layerHeight: 2.5rem;

--- a/apps/app/src/react/styles/group.scss
+++ b/apps/app/src/react/styles/group.scss
@@ -65,7 +65,7 @@ $margin-v: 2rem;
 			.title,
 			.edit-title {
 				margin-right: 1rem;
-				font-family: 'Barlow';
+				font-family: $mainFont;
 				font-weight: 700;
 				max-width: 10.8rem;
 			}

--- a/apps/app/src/react/styles/layer.scss
+++ b/apps/app/src/react/styles/layer.scss
@@ -125,7 +125,7 @@
 				}
 
 				.duration {
-					font-family: 'Barlow Condensed';
+					font-family: $mainFontCondensed;
 					font-variant-numeric: tabular-nums;
 					font-weight: 500;
 					color: rgba(255, 255, 255, 0.7);

--- a/apps/app/src/react/styles/part.scss
+++ b/apps/app/src/react/styles/part.scss
@@ -255,7 +255,7 @@ $part_time_height: 16px;
 		background: $emptyLayerColor;
 		display: flex;
 		flex-direction: column;
-		font-family: 'Barlow Condensed';
+		font-family: $mainFontCondensed;
 		max-width: 100px;
 		border-right: 1px;
 		border-color: black;
@@ -298,7 +298,7 @@ $part_time_height: 16px;
 		grid-area: time;
 		display: flex;
 		font-size: 14px;
-		font-family: 'Barlow Semi Condensed';
+		font-family: $mainFontSemiCondensed;
 		font-weight: 400;
 		font-variant-numeric: tabular-nums;
 		// overflow: hidden;
@@ -326,7 +326,7 @@ $part_time_height: 16px;
 			padding-right: 4px;
 
 			line-height: 1;
-			font-family: 'Barlow Condensed';
+			font-family: $mainFontCondensed;
 			font-weight: 300;
 			text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000,
 				0px 0px 3px rgba(0, 0, 0, 0.75);

--- a/apps/app/src/react/styles/sidebar/sidebar.scss
+++ b/apps/app/src/react/styles/sidebar/sidebar.scss
@@ -4,13 +4,13 @@
 	left: 0;
 	right: 0;
 	bottom: 0;
+	display: grid;
+	grid-template-columns: 100%;
+	grid-template-rows: min-content auto;
 
 	> .sidebar__header {
-		position: absolute;
-		top: 0;
-		left: 0;
-		right: 0;
-		// height is set programatically
+		grid-row: 1;
+		grid-column: 1;
 
 		padding: 0.5em;
 
@@ -19,7 +19,6 @@
 		.title {
 			font-size: 1.2rem;
 			text-transform: uppercase;
-			margin-bottom: 0.5rem;
 			font-weight: bold;
 			display: flex;
 			justify-content: space-between;
@@ -27,10 +26,9 @@
 		}
 	}
 	> .sidebar__content {
-		position: absolute;
-		bottom: 0;
-		left: 0;
-		right: 0;
+		position: relative;
+		grid-row: 2;
+		grid-column: 1;
 		// top is set programatically
 
 		z-index: 1;

--- a/apps/app/src/react/styles/trigger.scss
+++ b/apps/app/src/react/styles/trigger.scss
@@ -1,37 +1,35 @@
 .trigger-pill {
+	display: flex;
+	align-items: center;
+	font-family: $mainFontSemiCondensed;
+	font-weight: 600;
+	font-size: 12px;
+	// line-height: 12px;
 
-    display: flex;
-    align-items: center;
-    font-family: 'Barlow Semi Condensed';
-    font-weight: 600;
-    font-size: 12px;
-    // line-height: 12px;
+	margin-left: 0.5em;
 
-    margin-left: 0.5em;
+	> .label-part {
+		color: black;
+		background: #49d3ff;
+		box-shadow: inset 0px -2px 0px rgba(0, 0, 0, 0.25);
+		border-radius: 2px;
+		padding: 0 0.3rem;
 
-    >.label-part {
-        color: black;
-        background: #49d3ff;
-        box-shadow: inset 0px -2px 0px rgba(0, 0, 0, 0.25);
-        border-radius: 2px;
-        padding: 0 0.3rem;
+		&.keyboard {
+			background: #aaa99e;
+		}
 
-        &.keyboard {
-            background: #aaa99e;
-        }
+		> .label {
+			display: block;
+			transform: translateY(-1px);
+		}
+	}
 
-        >.label {
-            display: block;
-            transform: translateY(-1px);
-        }
-    }
+	.connect-labels {
+		margin: 0 0.2rem;
 
-    .connect-labels {
-        margin: 0 0.2rem;
-
-        &:last-child {
-            display: none;
-        }
-    }
-
+		&:last-child {
+			display: none;
+		}
+	}
 }


### PR DESCRIPTION
This PR adds a new, expandable filter that allows filtering both on Device and Resource Type.

![obraz](https://user-images.githubusercontent.com/3635991/196729439-8accb306-215b-45e8-a907-f4e9386568b4.png)

Also, the styling for the filters and resource library was refactored a little for simplicity.
Also, added a clear button for the name filter.
Also, cleaned up the styles a little bit.

I think this resolves: https://github.com/SuperFlyTV/SuperConductor/issues/99
