### PR TITLE
feat: Add labels to elapsed and remaining timers

### DIFF
--- a/apps/app/src/react/components/rundown/GroupView/part/CurrentTime/CurrentTime.tsx
+++ b/apps/app/src/react/components/rundown/GroupView/part/CurrentTime/CurrentTime.tsx
@@ -22,5 +22,12 @@ export const CurrentTime = observer(function CurrentTime(props: PropsType) {
 		const playheadTime = playhead.playheadTime
 		return typeof playheadTime === 'number' ? formatDuration(playheadTime, DISPLAY_DECIMAL_COUNT) : null
 	}, [props.groupId, props.partId])
-	return <>{playheadTimeString}</>
+
+	if (!playheadTimeString) return null
+
+	return (
+		<>
+			ELAPSED <span style={{ fontWeight: 400, fontFamily: 'Barlow Semi Condensed' }}>{playheadTimeString}</span>
+		</>
+	)
 })

--- a/apps/app/src/react/components/rundown/GroupView/part/RemainingTime/RemainingTime.tsx
+++ b/apps/app/src/react/components/rundown/GroupView/part/RemainingTime/RemainingTime.tsx
@@ -24,5 +24,10 @@ export const RemainingTime = observer(function RemainingTime(props: PropsType) {
 
 	if (!countDownTimeString) return null
 
-	return <>{countDownTimeString}</>
+	return (
+		<>
+			REMAINING{' '}
+			<span style={{ fontWeight: 400, fontFamily: 'Barlow Semi Condensed' }}>{countDownTimeString}</span>
+		</>
+	)
 })

--- a/apps/app/src/react/styles/part.scss
+++ b/apps/app/src/react/styles/part.scss
@@ -308,6 +308,8 @@ $part_time_height: 16px;
 			margin-left: 3px;
 			position: relative;
 			top: -2px;
+			font-family: 'Barlow Condensed';
+			font-weight: 300;
 		}
 
 		&__remaining-time {
@@ -315,6 +317,8 @@ $part_time_height: 16px;
 			margin-right: 88px;
 			position: relative;
 			top: -2px;
+			font-family: 'Barlow Condensed';
+			font-weight: 300;
 		}
 
 		&__duration {


### PR DESCRIPTION
First attempt at resolving #70 with some basic labels for the elapsed and remaining timers.

<img width="799" alt="Screenshot 2022-11-15 at 09 34 27" src="https://user-images.githubusercontent.com/12292660/201907194-947c9ec4-e893-4190-86e2-8b96c290e585.png">