### PR TITLE
fix: don't corrupt data when changing the type of a CasparCG timeline obj

### DIFF
--- a/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/casparcg.tsx
+++ b/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/casparcg.tsx
@@ -19,6 +19,7 @@ import {
 	TSRTransitionOptions,
 	BlendMode,
 	Chroma,
+	DeviceType,
 } from 'timeline-state-resolver-types'
 import { EditWrapper, OnSave } from './lib'
 import { BooleanInput } from '../../../inputs/BooleanInput'
@@ -55,6 +56,79 @@ export const EditTimelineObjCasparCGAny: React.FC<{ obj: TimelineObjCasparCGAny;
 					options={TimelineContentTypeCasparCg}
 					onChange={(newValue) => {
 						obj.content.type = newValue
+
+						const sharedContentProps = <T extends TimelineContentTypeCasparCg>(
+							type: T
+						): {
+							deviceType: DeviceType.CASPARCG
+							type: T
+						} => {
+							return {
+								deviceType: DeviceType.CASPARCG,
+								type,
+							}
+						}
+
+						// Create new content that is appropriate for the new CCG timelineObj type
+						switch (obj.content.type) {
+							case TimelineContentTypeCasparCg.HTMLPAGE: {
+								obj.content = {
+									...sharedContentProps(obj.content.type),
+									url: '',
+								}
+								break
+							}
+							case TimelineContentTypeCasparCg.INPUT: {
+								obj.content = {
+									...sharedContentProps(obj.content.type),
+									inputType: '',
+									device: 0,
+									deviceFormat: ChannelFormat.HD_1080P2500,
+								}
+								break
+							}
+							case TimelineContentTypeCasparCg.IP: {
+								obj.content = {
+									...sharedContentProps(obj.content.type),
+									uri: '',
+								}
+								break
+							}
+							case TimelineContentTypeCasparCg.MEDIA: {
+								obj.content = {
+									...sharedContentProps(obj.content.type),
+									file: '',
+								}
+								break
+							}
+							case TimelineContentTypeCasparCg.RECORD: {
+								obj.content = {
+									...sharedContentProps(obj.content.type),
+									file: '',
+									encoderOptions: '',
+								}
+								break
+							}
+							case TimelineContentTypeCasparCg.ROUTE: {
+								obj.content = {
+									...sharedContentProps(obj.content.type),
+								}
+								break
+							}
+							case TimelineContentTypeCasparCg.TEMPLATE: {
+								obj.content = {
+									...sharedContentProps(obj.content.type),
+									templateType: 'html',
+									name: '',
+									useStopCommand: false,
+									data: {},
+								}
+								break
+							}
+							default:
+								assertNever(obj.content)
+						}
+
 						onSave(obj)
 					}}
 				/>


### PR DESCRIPTION
This PR fixes an issue where changing the "Type" dropdown of a CasparCG timeline object would cause data corruption and UI crashes. Of note is that we still only support the `MEDIA` and `TEMPLATE` types -- the rest result in gray timelineObjs that display a raw ID, as shown below:

![image](https://user-images.githubusercontent.com/873012/206582067-4772e834-ac36-4403-a71b-6f24bde5a498.png)

Closes #119 
