### PR TITLE
Fix: app tsconfig exclude dist

### DIFF
--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -6,7 +6,5 @@
 		"jsx": "react",
 		"baseUrl": "./"
 	},
-	"exclude": [
-		"src/**/__tests__/**/*"
-	]
+	"exclude": ["src/**/__tests__/**/*", "dist/**/*"]
 }


### PR DESCRIPTION
I got an error that said the apps/app project could not write .d.ts fils to dist/, as dist/ would then be added back into the source of the project again.

I haven't researched the problem/solution again. Since I didn't see any explicit include-property in the tsconfig, I ended up just blindly excluding dist/, and the error went away.

Not testet/qualified in any other way. I might be wrong here.