### PR TITLE
fix: reorders playback controls into a logical order that feels more …

### DIFF
--- a/apps/app/src/react/components/rundown/GroupView/GroupView.tsx
+++ b/apps/app/src/react/components/rundown/GroupView/GroupView.tsx
@@ -1193,9 +1193,9 @@ const GroupControlButtons: React.FC<{
 
 	return (
 		<>
-			<PauseBtn groupId={group.id} data={data} onClick={handlePause} />
 			<StopBtn className="part__stop" groupId={group.id} data={data} onClick={handleStop} />
 			<PlayBtn groupId={group.id} data={data} onClick={handlePlay} />
+			<PauseBtn groupId={group.id} data={data} onClick={handlePause} />
 			<Button
 				variant="contained"
 				size="small"

--- a/apps/app/src/react/components/rundown/GroupView/GroupView.tsx
+++ b/apps/app/src/react/components/rundown/GroupView/GroupView.tsx
@@ -1193,21 +1193,9 @@ const GroupControlButtons: React.FC<{
 
 	return (
 		<>
+			<PauseBtn groupId={group.id} data={data} onClick={handlePause} />
 			<StopBtn className="part__stop" groupId={group.id} data={data} onClick={handleStop} />
 			<PlayBtn groupId={group.id} data={data} onClick={handlePlay} />
-			<PauseBtn groupId={group.id} data={data} onClick={handlePause} />
-			<Button
-				variant="contained"
-				size="small"
-				disabled={!canStepDown}
-				onClick={handleStepDown}
-				sx={{ visibility: group.oneAtATime ? 'visible' : 'hidden' }}
-				title="Play next"
-			>
-				<div style={{ transform: 'rotate(90deg) translateY(3px)' }}>
-					<AiFillStepForward size={22} />
-				</div>
-			</Button>
 			<Button
 				variant="contained"
 				size="small"
@@ -1217,6 +1205,18 @@ const GroupControlButtons: React.FC<{
 				title="Play previous"
 			>
 				<div style={{ transform: 'rotate(-90deg) translateY(3px)' }}>
+					<AiFillStepForward size={22} />
+				</div>
+			</Button>
+			<Button
+				variant="contained"
+				size="small"
+				disabled={!canStepDown}
+				onClick={handleStepDown}
+				sx={{ visibility: group.oneAtATime ? 'visible' : 'hidden' }}
+				title="Play next"
+			>
+				<div style={{ transform: 'rotate(90deg) translateY(3px)' }}>
 					<AiFillStepForward size={22} />
 				</div>
 			</Button>


### PR DESCRIPTION
…natural in parts of the world reading left-to-right, which is what the rest of the UI alrady assumes.

**Before:** 
![image](https://user-images.githubusercontent.com/6236874/236911647-0a8c8fe3-481a-47a6-8c68-fca3faaa9bbf.png)

**After:**
<img width="176" alt="image" src="https://user-images.githubusercontent.com/6236874/237011693-edee7526-3af8-4178-b612-8aeaf0c6e851.png">

