### PR TITLE
feat: persist group collapsed state

### DIFF
--- a/apps/app/src/electron/IPCServer.ts
+++ b/apps/app/src/electron/IPCServer.ts
@@ -1886,6 +1886,29 @@ export class IPCServer
 			description: ActionDescription.ToggleGroupLock,
 		}
 	}
+	async toggleGroupCollapse(arg: {
+		rundownId: string
+		groupId: string
+		value: boolean
+	}): Promise<UndoableResult<void>> {
+		const { rundown, group } = this.getGroup(arg)
+		const originalValue = Boolean(group.collapsed)
+
+		group.collapsed = arg.value
+
+		this._saveUpdates({ rundownId: arg.rundownId, rundown, group, noEffectOnPlayout: true })
+
+		return {
+			undo: () => {
+				const { rundown, group } = this.getGroup(arg)
+
+				group.collapsed = originalValue
+
+				this._saveUpdates({ rundownId: arg.rundownId, rundown, group, noEffectOnPlayout: true })
+			},
+			description: ActionDescription.ToggleGroupCollapse,
+		}
+	}
 	async refreshResources(): Promise<void> {
 		this.callbacks.refreshResources()
 	}

--- a/apps/app/src/ipc/IPCAPI.ts
+++ b/apps/app/src/ipc/IPCAPI.ts
@@ -39,6 +39,7 @@ export const enum ActionDescription {
 	toggleGroupOneAtATime = 'toggle group one-at-a-time',
 	ToggleGroupDisable = 'toggle group disable',
 	ToggleGroupLock = 'toggle group lock',
+	ToggleGroupCollapse = 'toggle group collapse',
 	NewRundown = 'new rundown',
 	DeleteRundown = 'delete rundown',
 	OpenRundown = 'open rundown',
@@ -194,6 +195,7 @@ export interface IPCServerMethods {
 	toggleGroupOneAtATime: (arg: { rundownId: string; groupId: string; value: boolean }) => void
 	toggleGroupDisable: (arg: { rundownId: string; groupId: string; value: boolean }) => void
 	toggleGroupLock: (arg: { rundownId: string; groupId: string; value: boolean }) => void
+	toggleGroupCollapse: (arg: { rundownId: string; groupId: string; value: boolean }) => void
 	refreshResources: () => void
 	refreshResourcesSetAuto: (arg: { interval: number }) => void
 	triggerHandleAutoFill: () => void

--- a/apps/app/src/models/rundown/Group.ts
+++ b/apps/app/src/models/rundown/Group.ts
@@ -33,6 +33,9 @@ export interface GroupBase {
 
 	/** This is populated by the backend, as the timeline is build. */
 	preparedPlayData: GroupPreparedPlayData | null
+
+	/** Whether or not this Group should be visually collapsed in the app view. Does not affect playout. */
+	collapsed?: boolean
 }
 export interface PlayingPart {
 	/** Timestamp of when the part started playing (unix timestamp) */

--- a/apps/app/src/react/api/IPCServer.ts
+++ b/apps/app/src/react/api/IPCServer.ts
@@ -180,6 +180,9 @@ export class IPCServer implements Promisify<IPCServerMethods> {
 	async toggleGroupLock(...args: ServerArgs<'toggleGroupLock'>): ServerReturn<'toggleGroupLock'> {
 		return this.invokeServerMethod('toggleGroupLock', ...args)
 	}
+	async toggleGroupCollapse(...args: ServerArgs<'toggleGroupCollapse'>): ServerReturn<'toggleGroupCollapse'> {
+		return this.invokeServerMethod('toggleGroupCollapse', ...args)
+	}
 	async refreshResources(...args: ServerArgs<'refreshResources'>): ServerReturn<'refreshResources'> {
 		return this.invokeServerMethod('refreshResources', ...args)
 	}

--- a/apps/app/src/react/components/rundown/GroupView/GroupView.tsx
+++ b/apps/app/src/react/components/rundown/GroupView/GroupView.tsx
@@ -115,10 +115,6 @@ export const GroupView: React.FC<{
 		setActiveParts(activeParts0)
 	}, [group])
 
-	const guiSettings = computed(() => store.guiStore.getGroupSettings(groupId))
-
-	const groupCollapsed = guiSettings.get().collapsed
-
 	const groupIsPlaying = computed(() => store.groupPlayDataStore.groups.get(group.id)?.groupIsPlaying || false).get()
 	const groupWillPlay = computed(
 		() => (store.groupPlayDataStore.groups.get(group.id)?.groupScheduledToPlay ?? []).length > 0 || false
@@ -436,11 +432,14 @@ export const GroupView: React.FC<{
 
 	// Collapse button:
 	const handleCollapse = useCallback(() => {
-		const settings = store.guiStore.getGroupSettings(groupId)
-		store.guiStore.setGroupSettings(groupId, {
-			collapsed: !settings.collapsed,
-		})
-	}, [groupId])
+		ipcServer
+			.toggleGroupCollapse({
+				rundownId,
+				groupId: group.id,
+				value: !group.collapsed,
+			})
+			.catch(handleError)
+	}, [group.collapsed, group.id, handleError, ipcServer, rundownId])
 
 	// Disable button:
 	const toggleDisable = useCallback(() => {
@@ -572,7 +571,7 @@ export const GroupView: React.FC<{
 					ref={wrapperRef}
 					className={classNames('group', {
 						disabled: group.disabled,
-						collapsed: groupCollapsed,
+						collapsed: group.collapsed,
 						dragging: isDragging,
 						selected: isSelected.get(),
 						selectable: selectable,
@@ -591,8 +590,8 @@ export const GroupView: React.FC<{
 						</div>
 
 						<div
-							className={classNames('collapse', { 'collapse--collapsed': groupCollapsed })}
-							title={groupCollapsed ? 'Expand Group' : 'Collapse Group'}
+							className={classNames('collapse', { 'collapse--collapsed': group.collapsed })}
+							title={group.collapsed ? 'Expand Group' : 'Collapse Group'}
 						>
 							<MdChevronRight size={22} onClick={handleCollapse} />
 						</div>
@@ -791,7 +790,7 @@ export const GroupView: React.FC<{
 							/>
 						</div>
 					</div>
-					{!groupCollapsed && (
+					{!group.collapsed && (
 						<div className="group__content">
 							<div
 								className="group__content__parts"

--- a/apps/app/src/react/mobx/GuiStore.ts
+++ b/apps/app/src/react/mobx/GuiStore.ts
@@ -236,7 +236,9 @@ export class GuiStore {
 	}
 }
 
-interface GroupSettings {
-	/** Whether or not this Group should be visually collapsed in the app view. Does not affect playout. */
-	collapsed?: boolean
-}
+/**
+ * This used to have content but doesn't anymore.
+ * We're keeping it around temporarily just in case it becomes useful again.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface GroupSettings {}


### PR DESCRIPTION
This PR allows the "collapsed" state of a group to be persisted to disk such that it is restored on application startup.

Helps #135 