### PR TITLE
feat: show a summary on collapsed groups

### DIFF
--- a/apps/app/src/react/components/rundown/GroupView/GroupView.tsx
+++ b/apps/app/src/react/components/rundown/GroupView/GroupView.tsx
@@ -779,7 +779,13 @@ export const GroupView: React.FC<{
 								<GroupAutoFillPopover rundownId={rundownId} group={group} />
 							</Popover>
 						</div>
-						<div className="controls controls-space"></div>
+						<div className="controls controls-space">
+							{groupCollapsed ? (
+								<div>
+									{group.partIds.length} {group.partIds.length === 1 ? 'Part' : 'Parts'}
+								</div>
+							) : null}
+						</div>
 						<div className="controls controls-right">
 							<DuplicateBtn className="duplicate" title="Duplicate Group" onClick={handleDuplicate} />
 

--- a/apps/app/src/react/styles/group.scss
+++ b/apps/app/src/react/styles/group.scss
@@ -100,6 +100,8 @@ $margin-v: 2rem;
 			}
 			&.controls-space {
 				flex-grow: 1;
+				display: flex;
+				justify-content: center;
 			}
 			&.controls-right {
 				cursor: initial;


### PR DESCRIPTION
Simple implementation, open to feedback and fine tuning:
![image](https://github.com/SuperFlyTV/SuperConductor/assets/873012/443ad547-364c-4938-b7e9-2abb61919601)

Helps #135, will conflict with #146 once it is merged due to this PR using the `groupCollapsed` var, which is removed by #146. Will be trivial to fix, just giving a heads up.