### PR TITLE
fix: small looping bugs

### DIFF
--- a/apps/app/src/lib/playout/__tests__/preparedGroupPlayData.test.ts
+++ b/apps/app/src/lib/playout/__tests__/preparedGroupPlayData.test.ts
@@ -754,6 +754,37 @@ describe('prepareGroupPlayData', () => {
 				}
 			}
 		})
+		test('Group with looping, w/o autoPlay, stops after first started Part', () => {
+			const group0 = getTestGroup()
+			expect(group0.oneAtATime).toBeTruthy()
+			group0.autoPlay = false
+			group0.loop = true
+
+			const partB = getPart(group0, 'partB')
+
+			// Play Part B:
+			RundownActions.playPart(group0, partB, 1000)
+			postProcessGroup(group0, 1000)
+
+			{
+				const prepared = prepareGroupPlayData(group0, 1001)
+				if (!prepared) throw new Error('Prepared is falsy')
+
+				expect(prepared.sections.length).toBe(1)
+				{
+					const playData = getGroupPlayData(prepared, 1001)
+
+					expect(playData).toMatchObject({
+						groupIsPlaying: true,
+						anyPartIsPlaying: true,
+						allPartsArePaused: false,
+						sectionTimeToEnd: 1999,
+						sectionEndTime: 3000,
+						sectionEndAction: SectionEndAction.STOP,
+					})
+				}
+			}
+		})
 	})
 
 	// Test cases to add:

--- a/apps/app/src/lib/playout/preparedGroupPlayData.ts
+++ b/apps/app/src/lib/playout/preparedGroupPlayData.ts
@@ -214,7 +214,7 @@ export function prepareGroupPlayData(group: Group, now?: number): GroupPreparedP
 					for (const part of playableParts) {
 						if (part.loop) {
 							endLoopingPart = part
-							section.repeating = false
+							loopSection.repeating = false
 							break
 						}
 
@@ -233,7 +233,9 @@ export function prepareGroupPlayData(group: Group, now?: number): GroupPreparedP
 							break
 						}
 					}
-					saveSection(data.sections, loopSection)
+					if (loopSection.parts.length) {
+						saveSection(data.sections, loopSection)
+					}
 				}
 
 				// Handle the case when a part is looping:

--- a/apps/app/src/lib/playout/preparedGroupPlayData.ts
+++ b/apps/app/src/lib/playout/preparedGroupPlayData.ts
@@ -193,7 +193,7 @@ export function prepareGroupPlayData(group: Group, now?: number): GroupPreparedP
 
 				saveSection(data.sections, section)
 
-				if (group.loop && section.endTime !== null && !endLoopingPart) {
+				if (group.loop && group.autoPlay && section.endTime !== null && !endLoopingPart) {
 					// Looping parts:
 
 					const loopSection: GroupPreparedPlayDataSection = {


### PR DESCRIPTION
This PR fixes two small issues with looping Parts in looping Groups in Single mode (one Part at a time), with auto-step:
1. In a looping Group, when Part A has looping enabled: After stepping to Parts B, C, and so on, the group would stop at the last part, instead of returning back to Part A.
2. In a looping Group, when Part B has looping enabled: After stepping to Parts C, D, and so on, the group would return back to Part A and loop that part instead of Part B.

Edit:

It also fixes an issue with looping Group in Single mode without auto-step:

3. Started Part was played out twice and then auto-stepping throughout the rest of the parts occurred instead of stopping after that part.