### PR TITLE
chore: enable inspector for Electron in dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
-.vscode/
+.vscode/*
+!.vscode/launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Electron Debug",
+			"type": "node",
+			"request": "attach",
+			"port": 9229
+		}
+	]
+}

--- a/apps/app/nodemon.json
+++ b/apps/app/nodemon.json
@@ -1,6 +1,6 @@
 {
 	"watch": ["src/**/*"],
 	"ignore": ["*.test.ts", "src/react/*", "README"],
-	"exec": "tsc -p tsconfig.electron.json && electron ./dist/main.js",
+	"exec": "tsc -p tsconfig.electron.json && electron ./dist/main.js --inspect=9229",
 	"ext": "ts"
 }


### PR DESCRIPTION
This PR enables debugging of the main Electron process of the dev build and adds launch configuration for attaching from VS Code. I think it's fine to have it always enabled in development mode, but if you think it should be optional, I will make it so.
Note: I'm not sure why lines 1-17 of .gitignore registered as changed. It could be the line endings.