### PR TITLE
fix: HTTP Send parameter key issues

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -84,6 +84,7 @@
 		"casparcg-connection": "^5.1.0",
 		"classnames": "^2.3.2",
 		"deep-extend": "^0.6.0",
+		"deepmerge-ts": "^5.1.0",
 		"electron-is-dev": "^2.0.0",
 		"electron-updater": "^5.3.0",
 		"file-loader": "^6.2.0",

--- a/apps/app/src/electron/IPCServer.ts
+++ b/apps/app/src/electron/IPCServer.ts
@@ -5,6 +5,7 @@ import {
 	allowMovingPartIntoGroup,
 	copyGroup,
 	copyPart,
+	deepExtendRemovingUndefined,
 	deleteGroup,
 	deletePart,
 	deleteTimelineObj,
@@ -1606,7 +1607,7 @@ export class IPCServer
 		const timelineObjPreChange = deepClone(timelineObj)
 		const timelineObjIndex = findTimelineObjIndex(part, arg.timelineObjId)
 
-		if (arg.timelineObj.obj !== undefined) deepExtend(timelineObj.obj, arg.timelineObj.obj)
+		if (arg.timelineObj.obj !== undefined) deepExtendRemovingUndefined(timelineObj.obj, arg.timelineObj.obj)
 
 		postProcessPart(part)
 		this._saveUpdates({ rundownId: arg.rundownId, rundown, group })

--- a/apps/app/src/lib/util.ts
+++ b/apps/app/src/lib/util.ts
@@ -23,6 +23,7 @@ import { assertNever, deepClone } from '@shared/lib'
 import shortUUID from 'short-uuid'
 import _ from 'lodash'
 import { describeTimelineObject } from './TimelineObj'
+import { deepmergeIntoCustom, getKeys } from 'deepmerge-ts'
 
 export const findGroup = (rundown: Rundown, groupId: string): Group | undefined => {
 	return rundown.groups.find((g) => g.id === groupId)
@@ -833,3 +834,14 @@ export function unReplaceUndefined(obj: any): any {
 	}
 	return obj
 }
+
+export const deepExtendRemovingUndefined = deepmergeIntoCustom({
+	mergeRecords(m_target, values, utils, meta) {
+		utils.defaultMergeFunctions.mergeRecords(m_target, values, utils, meta)
+		for (const key of getKeys(values)) {
+			if (values[1] && key in values[1] && values[1][key] === undefined) {
+				delete m_target.value[key]
+			}
+		}
+	},
+})

--- a/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/httpSend.tsx
+++ b/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/httpSend.tsx
@@ -71,19 +71,26 @@ export const EditTimelineObjHTTPSendAny: React.FC<{ objs: TimelineObjHTTPSendAny
 												// Ensure that the key is unique:
 												let i = 0
 												let vUnique = v
-												while (firstObj.content.params[vUnique] !== undefined) {
-													i++
-													vUnique = `${v}_${i}`
-												}
-
-												onSave({
+												const objectUpdates = {
 													content: {
-														params: {
-															[vUnique]: value,
-															[key]: undefined,
-														},
+														params: {},
 													},
-												})
+												}
+												if (v !== key) {
+													while (firstObj.content.params[vUnique] !== undefined) {
+														i++
+														vUnique = `${v}_${i}`
+													}
+													objectUpdates.content.params = {
+														[vUnique]: value,
+														[key]: undefined,
+													}
+												} else {
+													objectUpdates.content.params = {
+														[vUnique]: value,
+													}
+												}
+												onSave(objectUpdates)
 											}}
 											allowUndefined={false}
 										/>
@@ -108,7 +115,14 @@ export const EditTimelineObjHTTPSendAny: React.FC<{ objs: TimelineObjHTTPSendAny
 							variant="contained"
 							onClick={() => {
 								const numParams = Object.keys(firstObj.content.params).length
-								onSave({ content: { params: { [`param${numParams}`]: 'value' } } })
+								const v = `param${numParams}`
+								let i = 0
+								let vUnique = v
+								while (firstObj.content.params[vUnique] !== undefined) {
+									i++
+									vUnique = `${v}_${i}`
+								}
+								onSave({ content: { params: { [vUnique]: 'value' } } })
 							}}
 						>
 							Add Parameter

--- a/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/httpSend.tsx
+++ b/apps/app/src/react/components/sidebar/timelineObj/timelineObjs/httpSend.tsx
@@ -70,13 +70,15 @@ export const EditTimelineObjHTTPSendAny: React.FC<{ objs: TimelineObjHTTPSendAny
 											onChange={(v) => {
 												// Ensure that the key is unique:
 												let i = 0
-												let vUnique = v
 												const objectUpdates = {
 													content: {
-														params: {},
+														params: {
+															[v]: value,
+														},
 													},
 												}
 												if (v !== key) {
+													let vUnique = v
 													while (firstObj.content.params[vUnique] !== undefined) {
 														i++
 														vUnique = `${v}_${i}`
@@ -84,10 +86,6 @@ export const EditTimelineObjHTTPSendAny: React.FC<{ objs: TimelineObjHTTPSendAny
 													objectUpdates.content.params = {
 														[vUnique]: value,
 														[key]: undefined,
-													}
-												} else {
-													objectUpdates.content.params = {
-														[vUnique]: value,
 													}
 												}
 												onSave(objectUpdates)
@@ -115,14 +113,14 @@ export const EditTimelineObjHTTPSendAny: React.FC<{ objs: TimelineObjHTTPSendAny
 							variant="contained"
 							onClick={() => {
 								const numParams = Object.keys(firstObj.content.params).length
-								const v = `param${numParams}`
+								const key = `param${numParams}`
 								let i = 0
-								let vUnique = v
-								while (firstObj.content.params[vUnique] !== undefined) {
+								let keyUnique = key
+								while (firstObj.content.params[keyUnique] !== undefined) {
 									i++
-									vUnique = `${v}_${i}`
+									keyUnique = `${key}_${i}`
 								}
-								onSave({ content: { params: { [vUnique]: 'value' } } })
+								onSave({ content: { params: { [keyUnique]: 'value' } } })
 							}}
 						>
 							Add Parameter

--- a/yarn.lock
+++ b/yarn.lock
@@ -5214,6 +5214,11 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+deepmerge-ts@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/deepmerge-ts/-/deepmerge-ts-5.1.0.tgz#c55206cc4c7be2ded89b9c816cf3608884525d7a"
+  integrity sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==
+
 deepmerge@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"


### PR DESCRIPTION
This PR fixes three issues around `EditTimelineObjHTTPSendAny`
1. unwanted `_1` was appended to keys that were not duplicates, when the Key input was focused and un-focused without making a change
2. renamed or deleted parameters were kept as `undefined`, making the parameter count and numbering inaccurate
3. if _n_ parameters were defined, and one of them was named _param\<n\>_, it would get overwritten when adding a new parameter

Note: using deepmerge-ts with customized record merging was the cleanest thing I could come up with. Alternatively we could just stringify and parse those objects to have `undefined` removed, or avoid passing `undefined` between renderer and main process, and instead use some other way of marking properties to delete.