### PR TITLE
fix: Add option to set a custom label on timeline objects

### DIFF
--- a/apps/app/src/electron/IPCServer.ts
+++ b/apps/app/src/electron/IPCServer.ts
@@ -1597,9 +1597,7 @@ export class IPCServer
 		groupId: string
 		partId: string
 		timelineObjId: string
-		timelineObj: {
-			obj: PartialDeep<TimelineObj['obj']>
-		}
+		timelineObj: PartialDeep<Omit<TimelineObj, 'resolved'>>
 	}): Promise<UndoableResult<void> | undefined> {
 		const { rundown, group, part } = this.getPart(arg)
 
@@ -1615,6 +1613,7 @@ export class IPCServer
 		const timelineObjIndex = findTimelineObjIndex(part, arg.timelineObjId)
 
 		if (arg.timelineObj.obj !== undefined) deepExtendRemovingUndefined(timelineObj.obj, arg.timelineObj.obj)
+		if (arg.timelineObj.customLabel !== undefined) timelineObj.customLabel = arg.timelineObj.customLabel
 
 		postProcessPart(part)
 		this._saveUpdates({ rundownId: arg.rundownId, rundown, group })

--- a/apps/app/src/ipc/IPCAPI.ts
+++ b/apps/app/src/ipc/IPCAPI.ts
@@ -162,9 +162,7 @@ export interface IPCServerMethods {
 		groupId: string
 		partId: string
 		timelineObjId: string
-		timelineObj: {
-			obj: PartialDeep<TimelineObj['obj']>
-		}
+		timelineObj: PartialDeep<Omit<TimelineObj, 'resolved'>>
 	}) => void
 	deleteTimelineObj: (arg: { rundownId: string; groupId: string; partId: string; timelineObjId: string }) => void
 	insertTimelineObjs: (arg: {

--- a/apps/app/src/lib/TimelineObj.ts
+++ b/apps/app/src/lib/TimelineObj.ts
@@ -41,12 +41,14 @@ export interface TimelineObjectDescription {
 }
 
 export function describeTimelineObject(
-	obj: TSRTimelineObj<TSRTimelineContent>,
+	timelineObj: TimelineObj,
 	deviceMetadata?: MetadataAny | null
 ): TimelineObjectDescription {
+	const obj: TSRTimelineObj<TSRTimelineContent> = timelineObj.obj
 	let label: string = obj.id
 	let inTransition: TimelineObjectDescription['inTransition'] = undefined
 	let outTransition: TimelineObjectDescription['outTransition'] = undefined
+
 	if (obj.content.deviceType === DeviceType.CASPARCG) {
 		if (obj.content.type === TimelineContentTypeCasparCg.MEDIA) {
 			label = obj.content.file
@@ -276,6 +278,11 @@ export function describeTimelineObject(
 	} else {
 		// todo: for later:
 		// assertNever(obj.content)
+	}
+
+	if (timelineObj.customLabel !== undefined) {
+		const customLabel: string = `${timelineObj.customLabel || ''}`.trim()
+		if (customLabel) label = customLabel
 	}
 
 	// @ts-expect-error type

--- a/apps/app/src/lib/util.ts
+++ b/apps/app/src/lib/util.ts
@@ -833,7 +833,7 @@ export function getPartLabel(part: Part): string {
 	if (part.timeline) {
 		const firstTimelineObj = part.timeline[0]
 		if (firstTimelineObj) {
-			const description = describeTimelineObject(firstTimelineObj.obj)
+			const description = describeTimelineObject(firstTimelineObj)
 			return description.label
 		}
 	}

--- a/apps/app/src/models/rundown/TimelineObj.ts
+++ b/apps/app/src/models/rundown/TimelineObj.ts
@@ -3,6 +3,8 @@ import { TSRTimelineContent, TSRTimelineObj } from 'timeline-state-resolver-type
 export interface TimelineObj {
 	obj: TSRTimelineObj<TSRTimelineContent>
 
+	customLabel?: string
+
 	resolved: {
 		instances: TimelineObjResolvedInstance[]
 	}

--- a/apps/app/src/react/components/rundown/GroupView/TimelineObject.tsx
+++ b/apps/app/src/react/components/rundown/GroupView/TimelineObject.tsx
@@ -199,7 +199,7 @@ export const TimelineObject: React.FC<{
 		widthPercentage = null
 	}
 
-	const description = describeTimelineObject(obj, deviceMetadata)
+	const description = describeTimelineObject(timelineObj, deviceMetadata)
 
 	useEffect(() => {
 		const onKey = () => {

--- a/apps/app/src/react/components/sidebar/DataRow/DataRow.tsx
+++ b/apps/app/src/react/components/sidebar/DataRow/DataRow.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext } from 'react'
 import { useSnackbar } from 'notistack'
+import { Tooltip } from '@mui/material'
 import { ErrorHandlerContext } from '../../../contexts/ErrorHandler'
 
 import './style.scss'
@@ -22,15 +23,16 @@ export const DataRow = (props: { label: string; value: any }): JSX.Element => {
 			<div className="label" title={props.label}>
 				{props.label}
 			</div>
-			<div
-				className="value copy-to-clipboard"
-				title={`${props.value} (Click to copy)`}
-				onClick={() => {
-					void copyValueToClipboard()
-				}}
-			>
-				{props.value}
-			</div>
+			<Tooltip title={`Click to copy`}>
+				<div
+					className="value copy-to-clipboard"
+					onClick={() => {
+						void copyValueToClipboard()
+					}}
+				>
+					{props.value}
+				</div>
+			</Tooltip>
 		</div>
 	)
 }

--- a/apps/app/src/react/styles/sidebar/sidebar.scss
+++ b/apps/app/src/react/styles/sidebar/sidebar.scss
@@ -23,6 +23,15 @@
 			display: flex;
 			justify-content: space-between;
 			padding: 0.6em;
+
+			a {
+				color: inherit;
+				text-decoration: none;
+			}
+			a:hover {
+				text-decoration: underline;
+				cursor: text;
+			}
 		}
 	}
 	> .sidebar__content {


### PR DESCRIPTION
This PR adds an option to set a custom label on any timeline object.

This should solve the feature request described in https://github.com/SuperFlyTV/SuperConductor/issues/148

![customLabel](https://github.com/SuperFlyTV/SuperConductor/assets/15196563/37e321dc-e985-4102-a51e-5a0f9306a79a)
