### PR TITLE
Fix: bug in deep extend removing undefined

### DIFF
--- a/apps/app/src/lib/__tests__/util.test.ts
+++ b/apps/app/src/lib/__tests__/util.test.ts
@@ -19,4 +19,69 @@ test('deepExtendRemovingUndefined', () => {
 		})
 		expect(target).toStrictEqual({ a: [4, 5, 6] })
 	}
+
+	{
+		const target = {
+			arr: [1, 2, 3],
+			obj: {
+				num: 1,
+				arr: [
+					{
+						a: 1,
+					},
+					{
+						b: 2,
+					},
+				],
+				obj: {
+					a: 1,
+				},
+				toBeUndefined: {
+					a: 1,
+				},
+			},
+		}
+		deepExtendRemovingUndefined(target, {
+			arr: [3, 4, 5],
+			obj: {
+				num: 2,
+				arr: [
+					{
+						a: 2,
+					},
+					{
+						b: 3,
+					},
+					{
+						c: 4,
+					},
+				],
+				obj: {
+					b: 2,
+				},
+				toBeUndefined: undefined,
+			},
+		})
+		expect(target).toStrictEqual({
+			arr: [3, 4, 5],
+			obj: {
+				num: 2,
+				arr: [
+					{
+						a: 2,
+					},
+					{
+						b: 3,
+					},
+					{
+						c: 4,
+					},
+				],
+				obj: {
+					a: 1,
+					b: 2,
+				},
+			},
+		})
+	}
 })

--- a/apps/app/src/lib/__tests__/util.test.ts
+++ b/apps/app/src/lib/__tests__/util.test.ts
@@ -1,0 +1,22 @@
+import { deepExtendRemovingUndefined } from '../util'
+
+test('deepExtendRemovingUndefined', () => {
+	{
+		const target = {
+			a: 1,
+		}
+		deepExtendRemovingUndefined(target, {
+			b: 2,
+		})
+		expect(target).toStrictEqual({ a: 1, b: 2 })
+	}
+	{
+		const target = {
+			a: [1, 2, 3],
+		}
+		deepExtendRemovingUndefined(target, {
+			a: [4, 5, 6],
+		})
+		expect(target).toStrictEqual({ a: [4, 5, 6] })
+	}
+})

--- a/apps/app/src/lib/util.ts
+++ b/apps/app/src/lib/util.ts
@@ -871,4 +871,5 @@ export const deepExtendRemovingUndefined = deepmergeIntoCustom({
 			}
 		}
 	},
+	mergeArrays: false,
 })


### PR DESCRIPTION
There is a bug when adding a row to a table in GDD data.