### PR TITLE
refactor: undo/redo

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -92,6 +92,7 @@
 		"deepmerge-ts": "^5.1.0",
 		"electron-is-dev": "^2.0.0",
 		"electron-updater": "^5.3.0",
+		"eventemitter3": "^5.0.1",
 		"file-loader": "^6.2.0",
 		"formik": "^2.2.9",
 		"formik-mui": "^5.0.0-alpha.0",

--- a/apps/app/src/electron/ClientEventBus.ts
+++ b/apps/app/src/electron/ClientEventBus.ts
@@ -34,13 +34,13 @@ export class ClientEventBus extends EventEmitter<ClientEventBusEvents> implement
 		this.emit('callMethod', 'updateAppData', appData)
 	}
 	updateProject(project: Project): void {
-		this.emit('updateProject', project) // TODO: some type safety, please
+		this.emit('updateProject', project)
 	}
 	updateRundown(_fileName: string, rundown: Rundown): void {
-		this.emit('updateRundown', rundown) // TODO: some type safety, please
+		this.emit('updateRundown', rundown)
 	}
 	updateUndoLedgers(data: SerializableLedgers): void {
-		this.emit('updateUndoLedgers', data) // TODO: some type safety, please
+		this.emit('updateUndoLedgers', data)
 	}
 	updateResourcesAndMetadata(
 		resources: Array<{ id: ResourceId; resource: ResourceAny | null }>,

--- a/apps/app/src/electron/ClientEventBus.ts
+++ b/apps/app/src/electron/ClientEventBus.ts
@@ -11,10 +11,18 @@ import { ActiveAnalog } from '../models/rundown/Analog'
 import { AnalogInput } from '../models/project/AnalogInput'
 import { BridgeId } from '@shared/api'
 import { BridgePeripheralId } from '@shared/lib'
-import { EventEmitter } from 'stream'
+import EventEmitter from 'eventemitter3'
+import { SerializableLedgers } from '../models/project/Project'
+
+type ClientEventBusEvents = {
+	callMethod: (...args: any[]) => void // legacy
+	updateUndoLedgers: (undoLedgers: SerializableLedgers) => void
+	updateRundown: (rundown: Rundown) => void
+	updateProject: (rundown: Project) => void
+}
 
 // --- some of it might be needed, most of it hopefully not
-export class ClientEventBus extends EventEmitter implements IPCClientMethods {
+export class ClientEventBus extends EventEmitter<ClientEventBusEvents> implements IPCClientMethods {
 	close(): void {
 		// Nothing here
 	}
@@ -30,6 +38,9 @@ export class ClientEventBus extends EventEmitter implements IPCClientMethods {
 	}
 	updateRundown(_fileName: string, rundown: Rundown): void {
 		this.emit('updateRundown', rundown) // TODO: some type safety, please
+	}
+	updateUndoLedgers(data: SerializableLedgers): void {
+		this.emit('updateUndoLedgers', data) // TODO: some type safety, please
 	}
 	updateResourcesAndMetadata(
 		resources: Array<{ id: ResourceId; resource: ResourceAny | null }>,

--- a/apps/app/src/electron/EverythingService.ts
+++ b/apps/app/src/electron/EverythingService.ts
@@ -128,22 +128,6 @@ type ConvertToServerSide<T> = {
 		: T[K]
 }
 
-// const unreplaceUndefined = async (context: HookContext<any, EverythingService>, next: NextFunction) => {
-// 	context.arguments = unReplaceUndefined(context.arguments)
-// 	await next()
-// }
-
-// const undoable = async (context: HookContext<any, EverythingService>, next: NextFunction) => {
-// 	await next()
-// 	if (context.self && isUndoable(context.result)) {
-// 		context.self.registerUndoable(
-// 			context.arguments,
-// 			(context.self as any)[context.method ?? '']?.bind(context.self),
-// 			context.result
-// 		)
-// 	}
-// }
-
 function Undoable(target: EverythingService, _key: string, descriptor: PropertyDescriptor) {
 	const originalMethod = descriptor.value
 	descriptor.value = async function (...args: any) {
@@ -187,47 +171,6 @@ export class EverythingService
 		}
 	) {
 		super()
-		for (const methodName of Object.getOwnPropertyNames(EverythingService.prototype)) {
-			if (methodName[0] !== '_') {
-				const fcn = (this as any)[methodName].bind(this)
-				if (typeof fcn === 'function') {
-					// Monkey-patching methods in this class. There are definitely better ways to do it...
-					// ;(this as any)[methodName] = async (...args0: string[]) => {
-					// 	try {
-					// 		const args = unReplaceUndefined(args0)
-					// 		let result = fcn(...args)
-					// 		if (result instanceof Promise) result = await result
-					// 		if (isUndoable(result)) {
-					// 			// Clear any future things in the undo ledger:
-					// 			this.undoLedger.splice(this.undoPointer + 1, this.undoLedger.length)
-					// 			// Add the new action to the undo ledger:
-					// 			this.undoLedger.push({
-					// 				description: result.description,
-					// 				arguments: args,
-					// 				undo: result.undo,
-					// 				redo: fcn,
-					// 			})
-					// 			if (this.undoLedger.length > MAX_UNDO_LEDGER_LENGTH) {
-					// 				this.undoLedger.splice(0, this.undoLedger.length - MAX_UNDO_LEDGER_LENGTH)
-					// 			}
-					// 			this.undoPointer = this.undoLedger.length - 1
-					// 			this.emit('updatedUndoLedger', this.undoLedger, this.undoPointer)
-					// 			// string represents "anything but undefined" here:
-					// 			return (result as UndoableResult<string>).result
-					// 		} else {
-					// 			return result
-					// 		}
-					// 	} catch (error) {
-					// 		this.callbacks.handleError(
-					// 			`Error when calling ${methodName}: ${error}`,
-					// 			typeof error === 'object' && (error as any).stack
-					// 		)
-					// 		throw error
-					// 	}
-					// }
-				}
-			}
-		}
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/apps/app/src/electron/EverythingService.ts
+++ b/apps/app/src/electron/EverythingService.ts
@@ -83,13 +83,6 @@ import { SuperConductor } from './SuperConductor'
 import { UndoLedgerKey, UndoLedgerService } from './UndoService'
 import { SpecialLedgers } from '../models/project/Project'
 
-// type IPCServerEvents = {
-// 	updatedUndoLedger: (
-// 		undoLedger: Readonly<{ [key: string | symbol]: UndoLedger }>,
-// 		undoPointer: Readonly<UndoPointer>
-// 	) => void
-// }
-
 export function isUndoable(result: unknown): result is UndoableResult<any> {
 	if (typeof result !== 'object' || result === null) {
 		return false

--- a/apps/app/src/electron/EverythingService.ts
+++ b/apps/app/src/electron/EverythingService.ts
@@ -405,6 +405,7 @@ export class EverythingService implements ConvertToServerSide<IPCServerMethods> 
 		return rundown
 	}
 
+	@Undoable
 	async setPartTrigger(arg: {
 		rundownId: string
 		groupId: string

--- a/apps/app/src/electron/SuperConductor.ts
+++ b/apps/app/src/electron/SuperConductor.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, dialog, ipcMain } from 'electron'
+import { BrowserWindow, dialog } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { AutoFillMode, Group } from '../models/rundown/Group'
 import { EverythingService } from './EverythingService'
@@ -225,7 +225,7 @@ export class SuperConductor {
 			},
 		})
 
-		this.ipcServer = new EverythingService(ipcMain, this.log, this.renderLog, this.storage, this, this.session, {
+		this.ipcServer = new EverythingService(this.log, this.renderLog, this.storage, this, this.session, {
 			refreshResources: () => {
 				this.refreshResources()
 			},

--- a/apps/app/src/electron/UndoService.ts
+++ b/apps/app/src/electron/UndoService.ts
@@ -1,0 +1,110 @@
+import { LoggerLike } from '@shared/api'
+import { ActionDescription, UndoableResult } from '../ipc/IPCAPI'
+import EventEmitter from 'eventemitter3'
+import _ from 'lodash'
+import { SerializableLedgers } from '../models/project/Project'
+import { SpecialLedgers } from '../models/project/Project'
+
+export const MAX_UNDO_LEDGER_LENGTH = 100
+
+export interface UndoLedger {
+	actions: Action[]
+	pointer: UndoPointer
+}
+export type UndoLedgerKey = string | SpecialLedgers
+type UndoPointer = number
+type UndoFunction = () => Promise<void> | void
+export type UndoableFunction = (...args: any[]) => Promise<UndoableResult<any>>
+interface Action {
+	description: ActionDescription
+	arguments: unknown[]
+	redo: UndoableFunction
+	undo: UndoFunction
+}
+
+type UndoServiceEvents = {
+	updatedUndoLedger: (undoLedgers: SerializableLedgers) => void
+}
+
+export class UndoLedgerService extends EventEmitter<UndoServiceEvents> {
+	constructor(private _log: LoggerLike) {
+		super()
+	}
+	private undoLedgers = new Map<UndoLedgerKey, UndoLedger>()
+
+	public pushUndoable(key: UndoLedgerKey, args: unknown[], fcn: () => any, result: UndoableResult): void {
+		let ledger = this.undoLedgers.get(key)
+		if (!ledger) {
+			ledger = this.makeEmptyLedger()
+			this.undoLedgers.set(key, ledger)
+		}
+		ledger.actions.splice(ledger.pointer + 1, ledger.actions.length)
+		// Add the new action to the undo ledger:
+		ledger.actions.push({
+			description: result.description,
+			arguments: args,
+			undo: result.undo,
+			redo: fcn,
+		})
+		if (ledger.actions.length > MAX_UNDO_LEDGER_LENGTH) {
+			ledger.actions.splice(0, ledger.actions.length - MAX_UNDO_LEDGER_LENGTH)
+		}
+		ledger.pointer = ledger.actions.length - 1
+		this.emitUpdate()
+	}
+
+	private emitUpdate() {
+		this.emit('updatedUndoLedger', this.toSerializable())
+	}
+
+	public async undo(key: UndoLedgerKey): Promise<void> {
+		const ledger = this.undoLedgers.get(key)
+		const action = ledger?.actions?.[ledger?.pointer]
+		if (!action) return
+		try {
+			await action.undo()
+			ledger.pointer--
+		} catch (error) {
+			this._log.error('Error when undoing:', error)
+
+			// Clear
+			this.undoLedgers.set(key, this.makeEmptyLedger())
+		}
+		this.emitUpdate()
+	}
+
+	public async redo(key: UndoLedgerKey): Promise<void> {
+		const ledger = this.undoLedgers.get(key)
+		const action = ledger?.actions?.[ledger?.pointer + 1]
+		if (!action) return
+		try {
+			const redoResult = await action.redo(...action.arguments)
+			action.undo = redoResult.undo
+			ledger.pointer++
+		} catch (error) {
+			this._log.error('Error when redoing:', error)
+
+			// Clear
+			this.undoLedgers.set(key, this.makeEmptyLedger())
+		}
+		this.emitUpdate()
+	}
+
+	private makeEmptyLedger(): UndoLedger {
+		return {
+			actions: [],
+			pointer: -1,
+		}
+	}
+
+	private toSerializable(): SerializableLedgers {
+		return _.mapValues(Object.fromEntries<UndoLedger>(this.undoLedgers.entries()), (ledger: UndoLedger) => ({
+			undo: ledger.actions[ledger.pointer]
+				? { description: ledger.actions[ledger.pointer]?.description }
+				: undefined,
+			redo: ledger.actions[ledger.pointer + 1]
+				? { description: ledger.actions[ledger.pointer + 1]?.description }
+				: undefined,
+		}))
+	}
+}

--- a/apps/app/src/electron/api/ApiServer.ts
+++ b/apps/app/src/electron/api/ApiServer.ts
@@ -41,7 +41,7 @@ export class ApiServer {
 
 		this.app.use(ServiceName.PROJECTS, new ProjectService(this.app, ipcServer, clientEventBus), {
 			methods: ClientMethods[ServiceName.PROJECTS],
-			serviceEvents: ['created', ProjectsEvents.UPDATED, 'deleted'],
+			serviceEvents: ['created', ProjectsEvents.UPDATED, 'deleted', ProjectsEvents.UNDO_LEDGERS_UPDATED],
 		})
 
 		this.app.use(ServiceName.PARTS, new PartService(this.app, ipcServer, clientEventBus), {

--- a/apps/app/src/electron/api/ApiServer.ts
+++ b/apps/app/src/electron/api/ApiServer.ts
@@ -14,6 +14,7 @@ import { ClientMethods, ProjectsEvents, RundownsEvents, ServiceName, ServiceType
 import { Project, ProjectBase } from '../../models/project/Project'
 import { PartService } from './PartService'
 import { GroupService } from './GroupService'
+import { unReplaceUndefined } from '../../lib/util'
 
 export class ApiServer {
 	private app = koa<ServiceTypes>(feathers())
@@ -59,6 +60,17 @@ export class ApiServer {
 			methods: ClientMethods[ServiceName.REPORTING],
 			serviceEvents: [],
 			events: [],
+		})
+
+		// TODO: potentially may break some thing in ultra rare cases. Should we enable it only for selected methods?
+		this.app.hooks({
+			before: {
+				all: [
+					async (context: HookContext) => {
+						context.data = unReplaceUndefined(context.data)
+					},
+				],
+			},
 		})
 
 		this.app.service(ServiceName.RUNDOWNS).publish((data: Rundown, _context: HookContext) => {

--- a/apps/app/src/electron/api/ProjectService.ts
+++ b/apps/app/src/electron/api/ProjectService.ts
@@ -4,6 +4,7 @@ import EventEmitter from 'node:events'
 import { ProjectsEvents, ServiceTypes } from '../../ipc/IPCAPI'
 import { Project, ProjectBase } from '../../models/project/Project'
 import { ClientEventBus } from '../ClientEventBus'
+import { SerializableLedgers } from '../../models/project/Project'
 
 export const PROJECTS_CHANNEL_PREFIX = 'projects'
 export class ProjectService extends EventEmitter {
@@ -15,6 +16,9 @@ export class ProjectService extends EventEmitter {
 		super()
 		clientEventBus.on('updateProject', (project: Project) => {
 			this.emit(ProjectsEvents.UPDATED, project)
+		})
+		clientEventBus.on('updateUndoLedgers', (ledgers: SerializableLedgers) => {
+			this.emit(ProjectsEvents.UNDO_LEDGERS_UPDATED, ledgers)
 		})
 	}
 
@@ -66,15 +70,15 @@ export class ProjectService extends EventEmitter {
 		return await this.everythingService.importProject()
 	}
 
-	async undo(): Promise<void> {
+	async undo(data: { key: string }): Promise<void> {
 		// TODO: likely not the best place for this method
 		// TODO: access control
-		return await this.everythingService.undo()
+		return await this.everythingService.undo(data.key)
 	}
 
-	async redo(): Promise<void> {
+	async redo(data: { key: string }): Promise<void> {
 		// TODO: likely not the best place for this method
 		// TODO: access control
-		return await this.everythingService.redo()
+		return await this.everythingService.redo(data.key)
 	}
 }

--- a/apps/app/src/electron/api/ProjectService.ts
+++ b/apps/app/src/electron/api/ProjectService.ts
@@ -65,4 +65,16 @@ export class ProjectService extends EventEmitter {
 		// TODO: access control
 		return await this.everythingService.importProject()
 	}
+
+	async undo(): Promise<void> {
+		// TODO: likely not the best place for this method
+		// TODO: access control
+		return await this.everythingService.undo()
+	}
+
+	async redo(): Promise<void> {
+		// TODO: likely not the best place for this method
+		// TODO: access control
+		return await this.everythingService.redo()
+	}
 }

--- a/apps/app/src/ipc/IPCAPI.ts
+++ b/apps/app/src/ipc/IPCAPI.ts
@@ -51,6 +51,7 @@ type KeyArrays<T> = {
 type ServiceKeyArrays = KeyArrays<ServiceTypes>
 
 // TODO: this is temporary; Use decorators or something
+// those are the arrays of service methods exposed to the clients
 export const ClientMethods: ServiceKeyArrays = {
 	[ServiceName.GROUPS]: [
 		'create',
@@ -82,7 +83,18 @@ export const ClientMethods: ServiceKeyArrays = {
 		'deleteTimelineObj',
 		'insertTimelineObjs',
 	],
-	[ServiceName.PROJECTS]: ['get', 'create', 'update', 'getAll', 'open', 'import', 'export', 'unsubscribe'],
+	[ServiceName.PROJECTS]: [
+		'get',
+		'create',
+		'update',
+		'getAll',
+		'open',
+		'import',
+		'export',
+		'unsubscribe',
+		'undo',
+		'redo',
+	],
 	[ServiceName.REPORTING]: [
 		'log',
 		'handleClientError',
@@ -99,26 +111,8 @@ export const ClientMethods: ServiceKeyArrays = {
 		'isPlaying',
 		'close',
 		'open',
-		// 'pauseGroup',
-		// 'playGroup',
-		// 'playNext',
-		// 'playPrev',
-		// 'stopGroup',
 		'updateTimelineObj',
 		'moveTimelineObjToNewLayer',
-
-		// 'newPart',
-		// 'insertParts',
-		// 'updatePart',
-		// 'newGroup',
-		// 'insertGroups',
-		// 'updateGroup',
-		// 'deletePart',
-		// 'deleteGroup',
-		// 'moveParts',
-		// 'duplicatePart',
-		// 'moveGroups',
-		// 'duplicateGroup',
 	],
 }
 

--- a/apps/app/src/ipc/IPCAPI.ts
+++ b/apps/app/src/ipc/IPCAPI.ts
@@ -1,6 +1,6 @@
 import { PartialDeep } from 'type-fest'
 import { BridgeStatus } from '../models/project/Bridge'
-import { Project } from '../models/project/Project'
+import { Project, SerializableLedger } from '../models/project/Project'
 import { ResourceAny, ResourceId, MetadataAny, SerializedProtectedMap, TSRDeviceId } from '@shared/models'
 import { Rundown } from '../models/rundown/Rundown'
 import { TimelineObj } from '../models/rundown/TimelineObj'
@@ -23,8 +23,7 @@ import { type ProjectService } from '../electron/api/ProjectService'
 import { type ReportingService } from '../electron/api/ReportingService'
 import { type RundownService } from '../electron/api/RundownService'
 import { type GroupService } from '../electron/api/GroupService'
-
-export const MAX_UNDO_LEDGER_LENGTH = 100
+import { type SpecialLedgers } from '../models/project/Project'
 
 export enum ServiceName {
 	GROUPS = 'groups',
@@ -117,50 +116,55 @@ export const ClientMethods: ServiceKeyArrays = {
 }
 
 export const enum ActionDescription {
-	NewPart = 'create new part',
-	InsertParts = 'insert part(s)',
-	UpdatePart = 'update part',
+	NewPart = 'Create new part',
+	InsertParts = 'Insert part(s)',
+	UpdatePart = 'Update part',
 	SetPartTrigger = 'Assign trigger',
-	NewGroup = 'create new group',
-	InsertGroups = 'insert group(s)',
-	UpdateGroup = 'update group',
-	DeletePart = 'delete part',
-	DeleteGroup = 'delete group',
-	MovePart = 'move part',
-	MoveGroup = 'move group',
-	UpdateTimelineObj = 'update timeline object',
-	DeleteTimelineObj = 'delete timeline object',
-	AddTimelineObj = 'add timeline obj',
-	addResourcesToTimeline = 'add resource to timeline',
-	ToggleGroupLoop = 'toggle group loop',
-	ToggleGroupAutoplay = 'toggle group autoplay',
-	toggleGroupOneAtATime = 'toggle group one-at-a-time',
-	ToggleGroupDisable = 'toggle group disable',
-	ToggleGroupLock = 'toggle group lock',
-	ToggleGroupCollapse = 'toggle group collapse',
-	ToggleAllGroupsCollapse = 'toggle all groups collapse',
-	NewRundown = 'new rundown',
-	DeleteRundown = 'delete rundown',
-	OpenRundown = 'open rundown',
-	CloseRundown = 'close rundown',
-	RenameRundown = 'rename rundown',
-	MoveTimelineObjToNewLayer = 'move timeline object to new layer',
-	CreateMissingMapping = 'create missing layer',
-	DuplicateGroup = 'duplicate group',
-	DuplicatePart = 'duplicate part',
+	NewGroup = 'Create new group',
+	InsertGroups = 'Insert group(s)',
+	UpdateGroup = 'Update group',
+	DeletePart = 'Delete part',
+	DeleteGroup = 'Delete group',
+	MovePart = 'Move part',
+	MoveGroup = 'Move group',
+	UpdateTimelineObj = 'Update timeline object',
+	DeleteTimelineObj = 'Delete timeline object',
+	AddTimelineObj = 'Add timeline obj',
+	addResourcesToTimeline = 'Add resource to timeline',
+	ToggleGroupLoop = 'Toggle group loop',
+	ToggleGroupAutoplay = 'Toggle group autoplay',
+	toggleGroupOneAtATime = 'Toggle group one-at-a-time',
+	ToggleGroupDisable = 'Toggle group disable',
+	ToggleGroupLock = 'Toggle group lock',
+	ToggleGroupCollapse = 'Toggle group collapse',
+	ToggleAllGroupsCollapse = 'Toggle all groups collapse',
+	NewRundown = 'New rundown',
+	DeleteRundown = 'Delete rundown',
+	OpenRundown = 'Open rundown',
+	CloseRundown = 'Close rundown',
+	RenameRundown = 'Rename rundown',
+	MoveTimelineObjToNewLayer = 'Move timeline object to new layer',
+	CreateMissingMapping = 'Create missing layer',
+	DuplicateGroup = 'Duplicate group',
+	DuplicatePart = 'Duplicate part',
 	AddPeripheralArea = 'Add button area',
 	UpdatePeripheralArea = 'Update button area',
 	RemovePeripheralArea = 'Remove button area',
 	AssignAreaToGroup = 'Assign Area to Group',
 	// eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
 	SetApplicationTrigger = 'Assign trigger',
-	UpsertGroup = 'upsert group',
-	UpsertPart = 'upsert part',
+	UpsertGroup = 'Upsert group',
+	UpsertPart = 'Upsert part',
 }
 
 export type UndoFunction = () => Promise<void> | void
 
-export type UndoableResult<T = unknown> = { undo: UndoFunction; description: ActionDescription; result?: T }
+export type UndoableResult<T = unknown> = {
+	ledgerKey: string | SpecialLedgers
+	undo: UndoFunction
+	description: ActionDescription
+	result?: T
+}
 
 export type UndoableFunction = (...args: any[]) => Promise<UndoableResult>
 
@@ -169,6 +173,10 @@ export interface Action {
 	arguments: any[]
 	redo: UndoableFunction
 	undo: UndoFunction
+}
+
+export interface ElectronAPI {
+	updateUndoLedger: (key: string, data: SerializableLedger) => void
 }
 
 // --- legacy
@@ -369,4 +377,5 @@ export enum RundownsEvents {
 }
 export enum ProjectsEvents {
 	UPDATED = 'updated',
+	UNDO_LEDGERS_UPDATED = 'undo_ledgers_updated',
 }

--- a/apps/app/src/lib/__tests__/util.test.ts
+++ b/apps/app/src/lib/__tests__/util.test.ts
@@ -1,4 +1,5 @@
-import { deepExtendRemovingUndefined } from '../util'
+import { TimelineObj } from '../../models/rundown/TimelineObj'
+import { deepExtendRemovingUndefined, deleteTimelineObj } from '../util'
 
 test('deepExtendRemovingUndefined', () => {
 	{
@@ -84,4 +85,38 @@ test('deepExtendRemovingUndefined', () => {
 			},
 		})
 	}
+})
+
+function makeTestObject(id: string, start: string | number): TimelineObj {
+	return {
+		obj: {
+			content: {} as any,
+			enable: {
+				start,
+			},
+			id,
+			layer: '',
+		},
+		resolved: {} as any
+	}
+}
+
+describe('deleteTimelineObj', () => {
+	it('returns the same array if no changes', () => {
+		const timeline = [makeTestObject('obj1', '#obj2.end + 500'), makeTestObject('obj2', 1000)]
+		const result = deleteTimelineObj(timeline, 'obj3')
+		expect(result).toBe(timeline)
+	})
+
+	it('patches dependent objects', () => {
+		const timeline = [makeTestObject('obj1', '#obj2.end + 500'), makeTestObject('obj2', 1000)]
+		const result = deleteTimelineObj([makeTestObject('obj1', '#obj2.end + 500'), makeTestObject('obj2', 1000)], 'obj2')
+		expect(result).toEqual([makeTestObject('obj1', '1000 + 500')]) // not great, but acceptable
+	})
+
+	it('patches dependent objects 2', () => {
+		const timeline = [makeTestObject('obj1', '#obj2.end + 500'), makeTestObject('obj2', '#obj3.end'), makeTestObject('obj3', 0)]
+		const result = deleteTimelineObj(timeline, 'obj2')
+		expect(result).toEqual([makeTestObject('obj1', '#obj3.end + 500'), makeTestObject('obj3', 0)])
+	})
 })

--- a/apps/app/src/models/project/Project.ts
+++ b/apps/app/src/models/project/Project.ts
@@ -40,3 +40,17 @@ export interface AnalogInputSetting {
 	relativeMaxCap?: number
 	absoluteOffset?: number
 }
+
+export interface SerializableLedger {
+	undo?: { description?: string }
+	redo?: { description?: string }
+}
+
+export interface SerializableLedgers {
+	[key: string]: SerializableLedger
+}
+
+export enum SpecialLedgers {
+	APPLICATION = 'application',
+	PERIPHERALS = 'peripherals',
+}

--- a/apps/app/src/preload.ts
+++ b/apps/app/src/preload.ts
@@ -1,0 +1,8 @@
+import { contextBridge, ipcRenderer } from 'electron'
+import { ElectronAPI } from './ipc/IPCAPI'
+
+contextBridge.exposeInMainWorld('electronAPI', {
+	updateUndoLedger: (key, data) => {
+		ipcRenderer.send('updateUndoLedger', key, data)
+	},
+} satisfies ElectronAPI)

--- a/apps/app/src/react/App.tsx
+++ b/apps/app/src/react/App.tsx
@@ -519,16 +519,36 @@ export const App = observer(function App() {
 				handleError(error)
 			}
 		}
+		function onUndo(): void {
+			setUserAgreementScreenOpen(false)
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			serverAPI.undo().catch(handleError)
+		}
+		function onRedo(): void {
+			setUserAgreementScreenOpen(false)
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			serverAPI.redo().catch(handleError)
+		}
 		sorensen.bind('Escape', onEscapeKey, {
 			up: false,
 			global: true,
 			exclusive: true,
 			preventDefaultPartials: false,
 		})
+		sorensen.bind('Control+KeyZ', onUndo, {
+			up: false,
+			global: true,
+		})
+		sorensen.bind('Control+KeyY', onRedo, {
+			up: false,
+			global: true,
+		})
 		return () => {
 			sorensen.unbind('Escape', onEscapeKey)
+			sorensen.unbind('Control+KeyZ', onUndo)
+			sorensen.unbind('Control+KeyY', onRedo)
 		}
-	}, [sorensenInitialized, handleError, gui, currentRundownId])
+	}, [sorensenInitialized, handleError, gui, currentRundownId, serverAPI])
 
 	useMemoComputedValue(() => {
 		if (!project) return

--- a/apps/app/src/react/api/ApiClient.ts
+++ b/apps/app/src/react/api/ApiClient.ts
@@ -21,9 +21,9 @@ type PartArg<T extends keyof ServiceTypes[ServiceName.PARTS]> = Parameters<Servi
 type RundownArg<T extends keyof ServiceTypes[ServiceName.RUNDOWNS]> = Parameters<
 	ServiceTypes[ServiceName.RUNDOWNS][T]
 >[0]
-// type ProjectArg<T extends keyof ServiceTypes[ServiceName.PROJECTS]> = Parameters<
-// 	ServiceTypes[ServiceName.PROJECTS][T]
-// >[0]
+type ProjectArg<T extends keyof ServiceTypes[ServiceName.PROJECTS]> = Parameters<
+	ServiceTypes[ServiceName.PROJECTS][T]
+>[0]
 type ReportingArg<T extends keyof ServiceTypes[ServiceName.REPORTING]> = Parameters<
 	ServiceTypes[ServiceName.REPORTING][T]
 >[0]
@@ -330,10 +330,10 @@ export class ApiClient {
 	async setApplicationTrigger(...args: ServerArgs<'setApplicationTrigger'>): ServerReturn<'setApplicationTrigger'> {
 		return this.invokeServerMethod('setApplicationTrigger', ...args)
 	}
-	async undo(): Promise<void> {
-		return this.projectService.undo()
+	async undo(data: ProjectArg<'undo'>): Promise<void> {
+		return this.projectService.undo(data)
 	}
-	async redo(): Promise<void> {
-		return this.projectService.redo()
+	async redo(data: ProjectArg<'redo'>): Promise<void> {
+		return this.projectService.redo(data)
 	}
 }

--- a/apps/app/src/react/api/ApiClient.ts
+++ b/apps/app/src/react/api/ApiClient.ts
@@ -1,7 +1,7 @@
 import { ClientMethods, IPCServerMethods, ServiceName, ServiceTypes } from '../../ipc/IPCAPI'
 import { replaceUndefined } from '../../lib/util'
 
-import { feathers } from '@feathersjs/feathers'
+import { HookContext, feathers } from '@feathersjs/feathers'
 import socketio, { SocketService } from '@feathersjs/socketio-client'
 import io from 'socket.io-client'
 import { Rundown } from '../../models/rundown/Rundown'
@@ -60,6 +60,16 @@ app.use(
 		methods: ClientMethods[ServiceName.REPORTING],
 	}
 )
+
+app.hooks({
+	before: {
+		all: [
+			async (context: HookContext) => {
+				context.data = replaceUndefined(context.data)
+			},
+		],
+	},
+})
 
 type ServerArgs<T extends keyof IPCServerMethods> = Parameters<IPCServerMethods[T]>
 type ServerReturn<T extends keyof IPCServerMethods> = Promise<ReturnType<IPCServerMethods[T]>>
@@ -319,5 +329,11 @@ export class ApiClient {
 	}
 	async setApplicationTrigger(...args: ServerArgs<'setApplicationTrigger'>): ServerReturn<'setApplicationTrigger'> {
 		return this.invokeServerMethod('setApplicationTrigger', ...args)
+	}
+	async undo(): Promise<void> {
+		return this.projectService.undo()
+	}
+	async redo(): Promise<void> {
+		return this.projectService.redo()
 	}
 }

--- a/apps/app/src/react/api/ElectronApi.ts
+++ b/apps/app/src/react/api/ElectronApi.ts
@@ -1,0 +1,3 @@
+import { ElectronAPI } from '../../ipc/IPCAPI'
+
+export const ElectronApi = (window as any).electronAPI ? ((window as any).electronAPI as ElectronAPI) : undefined

--- a/apps/app/src/react/api/RealtimeDataProvider.ts
+++ b/apps/app/src/react/api/RealtimeDataProvider.ts
@@ -13,6 +13,7 @@ import { AnalogInput } from '../../models/project/AnalogInput'
 import { BridgeId } from '@shared/api'
 import { BridgePeripheralId } from '@shared/lib'
 import { app } from './ApiClient'
+import { SerializableLedgers } from '../../models/project/Project'
 
 /** This class is used client-side, to handle messages from the server */
 export class RealtimeDataProvider {
@@ -37,6 +38,7 @@ export class RealtimeDataProvider {
 			updateDefiningArea?: (definingArea: DefiningArea | null) => void
 			updateFailedGlobalTriggers?: (identifiers: string[]) => void
 			updateAnalogInput?: (fullIdentifier: string, analogInput: AnalogInput | null) => void
+			updateUndoLedgers?: (data: SerializableLedgers) => void
 		}
 	) {
 		// this is new:
@@ -44,7 +46,9 @@ export class RealtimeDataProvider {
 			this.updateRundown(rundown.id, rundown)
 		)
 		app.service(ServiceName.PROJECTS).on(ProjectsEvents.UPDATED, (project) => this.updateProject(project))
-		// app.service('project').on(...) etc.
+		app.service(ServiceName.PROJECTS).on(ProjectsEvents.UNDO_LEDGERS_UPDATED, (undoLedgers) =>
+			this.updateUndoLedgers(undoLedgers)
+		)
 
 		// this is temporary:
 		app.service(ServiceName.LEGACY).on('callMethod', (args) => this.handleCallMethod(args[0], args.slice(1)))
@@ -72,6 +76,9 @@ export class RealtimeDataProvider {
 	}
 	updateRundown(fileName: string, rundown: Rundown): void {
 		this.callbacks.updateRundown?.(fileName, rundown)
+	}
+	updateUndoLedgers(data: SerializableLedgers): void {
+		this.callbacks.updateUndoLedgers?.(data)
 	}
 	updateResourcesAndMetadata(
 		resources: Array<{ id: ResourceId; resource: ResourceAny | null }>,

--- a/apps/app/src/react/components/headerBar/deviceStatuses/DeviceStatuses.tsx
+++ b/apps/app/src/react/components/headerBar/deviceStatuses/DeviceStatuses.tsx
@@ -18,6 +18,7 @@ import { getPeripheralId } from '@shared/lib'
 export const DeviceStatuses: React.FC = observer(function DeviceStatuses() {
 	const project = useContext(ProjectContext)
 	const appStore = store.appStore
+	const gui = store.guiStore
 
 	const [submenuPopover, setSubmenuPopover] = React.useState<{
 		anchorEl: HTMLAnchorElement
@@ -26,7 +27,8 @@ export const DeviceStatuses: React.FC = observer(function DeviceStatuses() {
 	} | null>(null)
 	const closeSubMenu = useCallback(() => {
 		setSubmenuPopover(null)
-	}, [])
+		gui.isPeripheralPopoverOpen = true
+	}, [gui])
 
 	const [disabledPeripheralsPopover, setDisabledPeripheralsPopover] = React.useState<{
 		anchorEl: HTMLButtonElement
@@ -144,6 +146,7 @@ export const DeviceStatuses: React.FC = observer(function DeviceStatuses() {
 									bridgeId: peripheral.bridgeId,
 									deviceId: peripheral.id,
 								})
+								gui.isPeripheralPopoverOpen = true
 							}}
 						/>
 					)

--- a/apps/app/src/react/components/pages/homePage/HomePage.tsx
+++ b/apps/app/src/react/components/pages/homePage/HomePage.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Project } from 'src/models/project/Project'
+import { Project } from '../../../../models/project/Project'
 import { observer } from 'mobx-react-lite'
 import { store } from '../../../mobx/store'
 import { ProjectPage } from './projectPage/ProjectPage'

--- a/apps/app/src/react/mobx/AnalogStore.ts
+++ b/apps/app/src/react/mobx/AnalogStore.ts
@@ -4,7 +4,6 @@ import { ActiveAnalog } from '../../models/rundown/Analog'
 import { RealtimeDataProvider } from '../api/RealtimeDataProvider'
 import { ApiClient } from '../api/ApiClient'
 import { ClientSideLogger } from '../api/logger'
-// const { ipcRenderer } = window.require('electron')
 
 export class AnalogStore {
 	private analogInputs = new Map<string, AnalogInput>()

--- a/apps/app/src/react/mobx/AppStore.ts
+++ b/apps/app/src/react/mobx/AppStore.ts
@@ -9,10 +9,13 @@ import { setConstants } from '../constants'
 import { BridgeId } from '@shared/api'
 import { TSRDeviceId, protectString } from '@shared/models'
 import { BridgePeripheralId } from '@shared/lib'
+import { SerializableLedgers, SpecialLedgers } from '../../models/project/Project'
 
 export class AppStore {
 	bridgeStatuses = new Map<BridgeId, BridgeStatus>()
 	peripherals = new Map<BridgePeripheralId, PeripheralStatus>()
+	undoLedgers: SerializableLedgers = {}
+	undoLedgerCurrentKey: string = SpecialLedgers.APPLICATION
 
 	serverAPI: ApiClient
 	logger: ClientSideLogger
@@ -30,6 +33,7 @@ export class AppStore {
 				this.updateBridgeStatus(bridgeId, status),
 			updatePeripheral: (peripheralId: BridgePeripheralId, peripheral: PeripheralStatus | null) =>
 				this.updatePeripheral(peripheralId, peripheral),
+			updateUndoLedgers: (data: SerializableLedgers) => this.updateUndoLedgers(data),
 		})
 
 		makeAutoObservable(this)
@@ -67,6 +71,10 @@ export class AppStore {
 		} else {
 			this.peripherals.delete(peripheralId)
 		}
+	}
+
+	updateUndoLedgers(data: SerializableLedgers): void {
+		this.undoLedgers = data
 	}
 
 	private _updateAllDeviceStatuses() {

--- a/apps/app/src/react/mobx/GDDValidatorStoreStore.ts
+++ b/apps/app/src/react/mobx/GDDValidatorStoreStore.ts
@@ -1,7 +1,6 @@
 import { makeAutoObservable, runInAction } from 'mobx'
 import { SchemaValidator, setupSchemaValidator, ValidatorCache } from 'graphics-data-definition'
 import { ApiClient } from '../api/ApiClient'
-// const { ipcRenderer } = window.require('electron')
 
 export class GDDValidatorStore {
 	private isInitialized = false

--- a/apps/app/src/react/mobx/GroupPlayDataStore.ts
+++ b/apps/app/src/react/mobx/GroupPlayDataStore.ts
@@ -5,7 +5,6 @@ import { RealtimeDataProvider } from '../api/RealtimeDataProvider'
 import { Rundown } from '../../models/rundown/Rundown'
 import { ApiClient } from '../api/ApiClient'
 import { ClientSideLogger } from '../api/logger'
-// const { ipcRenderer } = window.require('electron')
 
 export class GroupPlayDataStore {
 	groups: Map<string, GroupPlayData> = new Map()

--- a/apps/app/src/react/mobx/GuiStore.ts
+++ b/apps/app/src/react/mobx/GuiStore.ts
@@ -10,7 +10,6 @@ import {
 } from '../../lib/GUI'
 import { DefiningArea } from '../../lib/triggers/keyDisplay/keyDisplay'
 import { ApiClient } from '../api/ApiClient'
-// const { ipcRenderer } = window.require('electron')
 
 /**
  * Store contains only information about user interface
@@ -90,6 +89,8 @@ export class GuiStore {
 	set activeTabId(id: string) {
 		this._activeTabId = id
 	}
+
+	public isPeripheralPopoverOpen = false
 
 	/** A list of all selected items */
 	get selected(): Readonly<CurrentSelectionAny[]> {

--- a/apps/app/src/react/mobx/ResourcesAndMetadataStore.ts
+++ b/apps/app/src/react/mobx/ResourcesAndMetadataStore.ts
@@ -1,6 +1,5 @@
 import { makeAutoObservable } from 'mobx'
 import { ApiClient } from '../api/ApiClient'
-// const { ipcRenderer } = window.require('electron')
 import { RealtimeDataProvider } from '../api/RealtimeDataProvider'
 import {
 	MetadataAny,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -17,7 +17,7 @@
 		"target": "es6" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
 		// "lib": ["es6"] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
 		// "jsx": "preserve",                                /* Specify what JSX code is generated. */
-		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+		"experimentalDecorators": true /* Enable experimental support for TC39 stage 2 draft decorators. */,
 		// "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
 		// "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
 		// "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -6433,6 +6433,11 @@ eventemitter3@^4.0.0, eventemitter3@^4.0.4, eventemitter3@^4.0.7:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 events@^3.2.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"


### PR DESCRIPTION
Addresses https://github.com/SuperFlyTV/SuperConductor/issues/174,
Makes undo/redo scoped to one of: current rundown, application (home), peripheral devices - depending on which section of the UI is active.
Disables `nodeIntegration` and enables `contextIsolation` for the main Electron app.