### PR TITLE
fix: changes rundown-tab selection from onClick to onMouseDown

### DIFF
--- a/apps/app/src/react/components/headerBar/tabs/Tabs.tsx
+++ b/apps/app/src/react/components/headerBar/tabs/Tabs.tsx
@@ -44,7 +44,7 @@ export const Tabs: React.FC<{ onTabDoubleClick: (rundown: any) => void }> = obse
 			<Tab
 				id="home"
 				name="Home"
-				onClick={() => {
+				onMouseDown={() => {
 					guiStore.goToHome()
 				}}
 				disableClose={true}
@@ -63,7 +63,7 @@ export const Tabs: React.FC<{ onTabDoubleClick: (rundown: any) => void }> = obse
 						id={rundown.rundownId}
 						name={rundown.name}
 						active={isThisSelected}
-						onClick={() => handleSelect(rundown.rundownId)}
+						onMouseDown={() => handleSelect(rundown.rundownId)}
 						onDoubleClick={() => props.onTabDoubleClick(rundown)}
 						// eslint-disable-next-line @typescript-eslint/no-misused-promises
 						onClose={async () => {

--- a/apps/app/src/react/components/headerBar/tabs/tab/Tab.tsx
+++ b/apps/app/src/react/components/headerBar/tabs/tab/Tab.tsx
@@ -8,7 +8,7 @@ export const Tab: React.FC<{
 	id: string
 	name: string
 	active?: boolean
-	onClick: () => void
+	onMouseDown: () => void
 	onDoubleClick?: () => void
 	onClose?: (id: string) => void
 	disableClose?: boolean
@@ -21,7 +21,7 @@ export const Tab: React.FC<{
 				active: props.active,
 			})}
 			title="Double-click to edit"
-			onClick={props.onClick}
+			onMouseDown={props.onMouseDown}
 			onDoubleClick={props.onDoubleClick}
 		>
 			{props.icon && <div className="icon">{props.icon}</div>}


### PR DESCRIPTION
To follow global UX conventions. Try clicking any tabs in any other app to verify the convention.