### PR TITLE
fix: Treat midi note on with 0 velocity as noteoff

### DIFF
--- a/shared/packages/peripherals/src/peripherals/midi.ts
+++ b/shared/packages/peripherals/src/peripherals/midi.ts
@@ -284,16 +284,16 @@ export class PeripheralMIDI extends Peripheral {
 					// Note on
 					const channel = data[0] & 15 // Second nibble
 					const keyNumber = data[1]
-					// const velocity = data[2]
+					const velocity = data[2]
 
 					const identifier = `${channel}_${keyNumber}`
 
 					this.seenKeys.set(identifier, {
 						channel,
 						keyNumber,
-						state: true,
+						state: velocity > 0,
 					})
-					this.emit('keyDown', identifier)
+					this.emit(velocity > 0 ? 'keyDown' : 'keyUp', identifier)
 				} else if (fcn === 2) {
 					// Polyphonic Key Pressure / Aftertouch
 					// Not supported


### PR DESCRIPTION
A lot of software (and hardware) do not send a note off but instead send a note on with a velocity of 0.

According to the spec itself this is normal behaviour:
> MIDI provides two roughly equivalent means of turning off a note (voice). A note may be turned off
either by sending a Note-Off message for the same note number and channel, or by sending a Note-On
message for that note and channel with a velocity value of zero. The advantage to using "Note-On at
zero velocity" is that it can avoid sending additional status bytes when Running Status is employed.

This change adds the proper check before updating/emitting the key state