### PR TITLE
chore: reconfigure typescript to be invoked once at the root level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist
 .env.development.local
 .env.test.local
 .env.production.local
+*.tsbuildinfo
 
 npm-debug.log*
 yarn-debug.log*

--- a/apps/app/nodemon.json
+++ b/apps/app/nodemon.json
@@ -1,6 +1,6 @@
 {
 	"watch": ["src/**/*"],
 	"ignore": ["*.test.ts", "src/react/*", "README"],
-	"exec": "run -B -T tsc -p tsconfig.electron.json && electron ./dist/main.mjs --inspect=9229",
+	"exec": "electron ./dist/main.mjs --inspect=9229",
 	"ext": "ts"
 }

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -9,8 +9,7 @@
 		"node": "20"
 	},
 	"scripts": {
-		"build": "run -B -T rimraf ./dist && run -B -T tsc -p tsconfig.build.json && vite build",
-		"build:electron": "run -B -T tsc -p tsconfig.build.json",
+		"build": "vite build",
 		"build:binary": "electron-builder",
 		"start": "run build && electron dist/main.mjs",
 		"react:dev": "vite",

--- a/apps/app/tsconfig.build.json
+++ b/apps/app/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist",
@@ -8,5 +8,13 @@
 		"baseUrl": "./"
 	},
 	"include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.mts"],
-	"exclude": ["src/**/__tests__/**/*", "dist/**/*"]
+	"exclude": ["src/**/__tests__/**/*", "dist/**/*"],
+	"references": [
+		//
+		{ "path": "../../shared/packages/api" },
+		{ "path": "../../shared/packages/lib" },
+		{ "path": "../../shared/packages/models" },
+		{ "path": "../../shared/packages/peripherals" },
+		{ "path": "../../shared/packages/tsr-bridge" }
+	]
 }

--- a/apps/app/tsconfig.electron.json
+++ b/apps/app/tsconfig.electron.json
@@ -1,9 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"exclude": [
-		"dist",
-		"src/renderer.tsx",
-		"src/react/**/*",
-		"src/**/__tests__/**/*"
-	]
-}

--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -3,6 +3,5 @@
 	"compilerOptions": {
 		"types": ["node", "jest"]
 	},
-	"include": ["src/**/*"],
 	"exclude": ["dist"]
 }

--- a/apps/tsr-bridge/package.json
+++ b/apps/tsr-bridge/package.json
@@ -9,7 +9,7 @@
 		"node": "20"
 	},
 	"scripts": {
-		"build": "run -B -T rimraf ./dist && run -B -T tsc && vite build",
+		"build": "vite build",
 		"build:binary": "electron-builder",
 		"start": "yarn build && electron dist/main.mjs",
 		"react:dev": "vite",

--- a/apps/tsr-bridge/tsconfig.json
+++ b/apps/tsr-bridge/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist",
@@ -8,5 +8,13 @@
 		"baseUrl": "./"
 	},
 	"include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.mts"],
-	"exclude": ["src/**/__tests__/**/*", "dist/**/*"]
+	"exclude": ["src/**/__tests__/**/*", "dist/**/*"],
+	"references": [
+		//
+		{ "path": "../../shared/packages/api" },
+		{ "path": "../../shared/packages/lib" },
+		{ "path": "../../shared/packages/models" },
+		{ "path": "../../shared/packages/peripherals" },
+		{ "path": "../../shared/packages/tsr-bridge" }
+	]
 }

--- a/package.json
+++ b/package.json
@@ -23,20 +23,21 @@
 		"lint:raw": "eslint",
 		"lint": "run lint:raw .",
 		"lintfix": "run lint --fix",
-		"build": "lerna run build",
+		"build": "run build:ts && lerna run build",
+		"build:ts": "(rimraf apps/*/dist || true) && (rimraf shared/packages/*/dist || true) && (rimraf apps/*/*.tsbuildinfo || true) && (rimraf shared/packages/*/*.tsbuildinfo || true) && tsc -b tsconfig.build.json",
 		"build:binary": "lerna run build:binary",
-		"build:shared": "lerna run build --stream --scope=@shared/\\*",
-		"build:shared:changed": "lerna run build --stream --scope=@shared/\\* --since head --exclude-dependents --stream",
-		"start": "yarn && run build:shared && run dev:electron",
-		"start:all": "run build:shared && lerna run dev --stream",
-		"start:bridge": "run build:shared && run dev:bridge",
+		"start": "yarn && run build:ts && run dev:electron",
+		"start:all": "run build:ts && lerna run dev --stream",
+		"start:bridge": "run build:ts && run dev:bridge",
 		"dev:electron": "lerna run dev --stream --scope=superconductor",
 		"dev:bridge": "lerna run dev --stream --scope=tsr-bridge",
 		"test": "lerna run test",
 		"license-validate": "node scripts/license-check.mjs",
 		"release:bump": "lerna version --force-publish --no-push",
 		"release:prerelease": "lerna version prerelease --force-publish --no-push",
-		"release:preminor": "lerna version preminor --force-publish --no-push"
+		"release:preminor": "lerna version preminor --force-publish --no-push",
+		"check-types": "tsc -b --noEmit",
+		"watch-types": "tsc -b --noEmit --watch"
 	},
 	"resolutions": {
 		"app-builder-bin": "npm:@julusian/app-builder-bin@4.0.1",
@@ -78,5 +79,5 @@
 			"yarn lint:raw --fix"
 		]
 	},
-	"packageManager": "yarn@4.5.0"
+	"packageManager": "yarn@4.9.1"
 }

--- a/shared/packages/api/package.json
+++ b/shared/packages/api/package.json
@@ -23,10 +23,6 @@
 		"type": "git",
 		"url": "git+https://github.com/SuperFlyTV/SuperConductor.git"
 	},
-	"scripts": {
-		"build": "run -B -T rimraf dist && yarn build:main",
-		"build:main": "run -B -T tsc -p tsconfig.json"
-	},
 	"bugs": {
 		"url": "https://github.com/SuperFlyTV/SuperConductor/issues"
 	},

--- a/shared/packages/api/tsconfig.json
+++ b/shared/packages/api/tsconfig.json
@@ -1,9 +1,13 @@
 {
-	"extends": "../../../tsconfig.json",
+	"extends": "../../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
-	"exclude": ["src/**/__tests__/**/*"]
+	"exclude": ["src/**/__tests__/**/*"],
+	"references": [
+		//
+		{ "path": "../models" }
+	]
 }

--- a/shared/packages/lib/package.json
+++ b/shared/packages/lib/package.json
@@ -23,10 +23,6 @@
 		"type": "git",
 		"url": "git+https://github.com/SuperFlyTV/SuperConductor.git"
 	},
-	"scripts": {
-		"build": "run -B -T rimraf dist && yarn build:main",
-		"build:main": "run -B -T tsc -p tsconfig.json"
-	},
 	"bugs": {
 		"url": "https://github.com/SuperFlyTV/SuperConductor/issues"
 	},

--- a/shared/packages/lib/tsconfig.json
+++ b/shared/packages/lib/tsconfig.json
@@ -1,8 +1,13 @@
 {
-	"extends": "../../../tsconfig.json",
+	"extends": "../../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist"
 	},
-	"include": ["src/**/*.ts"]
+	"include": ["src/**/*.ts"],
+	"references": [
+		//
+		{ "path": "../api" },
+		{ "path": "../models" }
+	]
 }

--- a/shared/packages/models/package.json
+++ b/shared/packages/models/package.json
@@ -23,10 +23,6 @@
 		"type": "git",
 		"url": "git+https://github.com/SuperFlyTV/SuperConductor.git"
 	},
-	"scripts": {
-		"build": "run -B -T rimraf dist && yarn build:main",
-		"build:main": "run -B -T tsc -p tsconfig.json"
-	},
 	"dependencies": {
 		"graphics-data-definition": "^1.1.1"
 	},

--- a/shared/packages/models/tsconfig.json
+++ b/shared/packages/models/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../tsconfig.json",
+	"extends": "../../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist"

--- a/shared/packages/peripherals/package.json
+++ b/shared/packages/peripherals/package.json
@@ -23,10 +23,6 @@
 		"type": "git",
 		"url": "git+https://github.com/SuperFlyTV/SuperConductor.git"
 	},
-	"scripts": {
-		"build": "run -B -T rimraf dist && yarn build:main",
-		"build:main": "run -B -T tsc -p tsconfig.json"
-	},
 	"bugs": {
 		"url": "https://github.com/SuperFlyTV/SuperConductor/issues"
 	},

--- a/shared/packages/peripherals/tsconfig.json
+++ b/shared/packages/peripherals/tsconfig.json
@@ -1,8 +1,14 @@
 {
-	"extends": "../../../tsconfig.json",
+	"extends": "../../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist"
 	},
-	"include": ["src/**/*.ts"]
+	"include": ["src/**/*.ts"],
+	"references": [
+		//
+		{ "path": "../api" },
+		{ "path": "../lib" },
+		{ "path": "../models" }
+	]
 }

--- a/shared/packages/server-lib/package.json
+++ b/shared/packages/server-lib/package.json
@@ -23,10 +23,6 @@
 		"type": "git",
 		"url": "git+https://github.com/SuperFlyTV/SuperConductor.git"
 	},
-	"scripts": {
-		"build": "run -B -T rimraf dist && yarn build:main",
-		"build:main": "run -B -T tsc -p tsconfig.json"
-	},
 	"bugs": {
 		"url": "https://github.com/SuperFlyTV/SuperConductor/issues"
 	},

--- a/shared/packages/server-lib/tsconfig.json
+++ b/shared/packages/server-lib/tsconfig.json
@@ -1,9 +1,14 @@
 {
-	"extends": "../../../tsconfig.json",
+	"extends": "../../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
-	"exclude": ["src/**/__tests__/**/*"]
+	"exclude": ["src/**/__tests__/**/*"],
+	"references": [
+		//
+		{ "path": "../api" },
+		{ "path": "../models" }
+	]
 }

--- a/shared/packages/tsr-bridge/package.json
+++ b/shared/packages/tsr-bridge/package.json
@@ -23,10 +23,6 @@
 		"type": "git",
 		"url": "git+https://github.com/SuperFlyTV/SuperConductor.git"
 	},
-	"scripts": {
-		"build": "run -B -T rimraf dist && yarn build:main",
-		"build:main": "run -B -T tsc -p tsconfig.json"
-	},
 	"bugs": {
 		"url": "https://github.com/SuperFlyTV/SuperConductor/issues"
 	},

--- a/shared/packages/tsr-bridge/tsconfig.json
+++ b/shared/packages/tsr-bridge/tsconfig.json
@@ -1,9 +1,16 @@
 {
-	"extends": "../../../tsconfig.json",
+	"extends": "../../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
-	"exclude": ["src/**/__tests__/**/*"]
+	"exclude": ["src/**/__tests__/**/*"],
+	"references": [
+		//
+		{ "path": "../api" },
+		{ "path": "../lib" },
+		{ "path": "../models" },
+		{ "path": "../peripherals" }
+	]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,18 @@
+{
+	"extends": "@tsconfig/node20/tsconfig.json",
+	"exclude": ["node_modules/**", "src/**/__tests__/*", "dist/**/*"],
+	"compilerOptions": {
+		"experimentalDecorators": true /* Enable experimental support for TC39 stage 2 draft decorators. */,
+		"types": ["node"],
+		"resolveJsonModule": true /* Enable importing .json files */,
+		"declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
+		"declarationMap": true /* Create sourcemaps for d.ts files. */,
+		"sourceMap": true /* Create source map files for emitted JavaScript files. */,
+		"esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
+		"forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+		"skipLibCheck": true /* Skip type checking all .d.ts files. */,
+		"allowSyntheticDefaultImports": true,
+		"composite": true /* Enable project compilation */,
+		"isolatedModules": true
+	}
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,16 +1,13 @@
 {
-	"extends": "@tsconfig/node20/tsconfig.json",
-	"exclude": ["node_modules/**", "src/**/__tests__/*", "dist/**/*"],
-	"compilerOptions": {
-		"experimentalDecorators": true /* Enable experimental support for TC39 stage 2 draft decorators. */,
-		"types": ["node"],
-		"resolveJsonModule": true /* Enable importing .json files */,
-		"declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
-		"declarationMap": true /* Create sourcemaps for d.ts files. */,
-		"sourceMap": true /* Create source map files for emitted JavaScript files. */,
-		"esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
-		"forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-		"skipLibCheck": true /* Skip type checking all .d.ts files. */,
-		"allowSyntheticDefaultImports": true
-	}
+	"files": [],
+	"references": [
+		{ "path": "./shared/packages/api/tsconfig.json" },
+		{ "path": "./shared/packages/lib/tsconfig.json" },
+		{ "path": "./shared/packages/models/tsconfig.json" },
+		{ "path": "./shared/packages/peripherals/tsconfig.json" },
+		{ "path": "./shared/packages/server-lib/tsconfig.json" },
+		{ "path": "./shared/packages/tsr-bridge/tsconfig.json" },
+		{ "path": "./apps/tsr-bridge/tsconfig.json" },
+		{ "path": "./apps/app/tsconfig.build.json" }
+	]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,13 @@
 {
-	"extends": "./tsconfig.build.json"
+	"files": [],
+	"references": [
+		{ "path": "./shared/packages/api/tsconfig.json" },
+		{ "path": "./shared/packages/lib/tsconfig.json" },
+		{ "path": "./shared/packages/models/tsconfig.json" },
+		{ "path": "./shared/packages/peripherals/tsconfig.json" },
+		{ "path": "./shared/packages/server-lib/tsconfig.json" },
+		{ "path": "./shared/packages/tsr-bridge/tsconfig.json" },
+		{ "path": "./apps/app/tsconfig.json" },
+		{ "path": "./apps/tsr-bridge/tsconfig.json" }
+	]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5877,7 +5877,7 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.2, csstype@npm:^3.1.3":
+"csstype@npm:^3.0.10, csstype@npm:^3.0.2, csstype@npm:^3.1.3":
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: 10c0/80c089d6f7e0c5b2bd83cf0539ab41474198579584fa10d86d0cafe0642202343cbc119e076a0b1aece191989477081415d66c9fefbf3c957fc2fc4b7009f248
@@ -15549,11 +15549,11 @@ asn1@evs-broadcast/node-asn1:
 
 "typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
   version: 5.8.2
-  resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=8c6c40"
+  resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/8a6cd29dfb59bd5a978407b93ae0edb530ee9376a5b95a42ad057a6f80ffb0c410489ccd6fe48d1d0dfad6e8adf5d62d3874bbd251f488ae30e11a1ce6dabd28
+  checksum: 10c0/5448a08e595cc558ab321e49d4cac64fb43d1fa106584f6ff9a8d8e592111b373a995a1d5c7f3046211c8a37201eb6d0f1566f15cdb7a62a5e3be01d087848e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This makes it more mono-repo like, with it aware of all the packages and their relationships. At the root level you can now run `yarn watch-types` and get a tidy overview of all the type errors and where they are.