### PR TITLE
chore/fix: Remove got library

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -87,7 +87,6 @@
 		"electron-updater": "^6.3.9",
 		"formik": "patch:formik@npm%3A2.2.9#~/.yarn/patches/formik-npm-2.2.9-0e8cb516ca.patch",
 		"formik-mui": "^5.0.0-alpha.0",
-		"got": "^14.4.3",
 		"graphics-data-definition": "1.1.1",
 		"koa": "^2.15.3",
 		"koa-bodyparser": "^4.4.1",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -105,7 +105,7 @@
 		"react-icons": "^5.3.0",
 		"react-toggle": "patch:react-toggle@npm%3A4.1.3#~/.yarn/patches/react-toggle-npm-4.1.3-6397672405.patch",
 		"react-visibility-sensor": "^5.1.1",
-		"semver": "^7.6.3",
+		"semver": "^7.7.1",
 		"short-uuid": "^5.2.0",
 		"socket.io-client": "^4.8.0",
 		"superfly-timeline": "^8.3.1",

--- a/apps/app/src/electron/telemetry.ts
+++ b/apps/app/src/electron/telemetry.ts
@@ -1,4 +1,3 @@
-import got from 'got'
 import os from 'os'
 import { app } from 'electron'
 import { CURRENT_VERSION } from './bridgeHandler.js'
@@ -135,19 +134,26 @@ export class TelemetryHandler {
 			// If there are errors, don't flood with requests:
 			if (errorCount < 3) {
 				try {
-					await got
-						// .post('http://superconductor-statistics/superconductor/reportUsageStatistics', {
-						// .post('http://localhost:2500/superconductor/reportUsageStatistics', {
-						.post(
-							// 'https://faas-ams3-2a2df116.doserverless.co/api/v1/web/fn-7ba9c1fc-f987-4993-b324-a86c98928fcb/telemetry/insert',
-							'https://faas-ams3-2a2df116.doserverless.co/api/v1/web/fn-7ba9c1fc-f987-4993-b324-a86c98928fcb/telemetry/insert',
-							{
-								json: {
-									report: report,
-								},
-							}
-						)
-						.json()
+					const response = await fetch(
+						// 'http://superconductor-statistics/superconductor/reportUsageStatistics',
+						// 'http://localhost:2500/superconductor/reportUsageStatistics',
+						// 'https://faas-ams3-2a2df116.doserverless.co/api/v1/web/fn-7ba9c1fc-f987-4993-b324-a86c98928fcb/telemetry/insert',
+						'https://faas-ams3-2a2df116.doserverless.co/api/v1/web/fn-7ba9c1fc-f987-4993-b324-a86c98928fcb/telemetry/insert',
+						{
+							method: 'POST',
+							headers: {
+								'Content-Type': 'application/json',
+							},
+							body: JSON.stringify({
+								report: report,
+							}),
+						}
+					)
+					// Not sure if this is needed, but something equivalent was in the previous version
+					if (!response.ok) {
+						throw new Error(`HTTP error! status: ${response.status}`)
+					}
+					await response.json()
 				} catch (error: any) {
 					// For a strange reason we get an error even though it all works
 

--- a/shared/packages/tsr-bridge/package.json
+++ b/shared/packages/tsr-bridge/package.json
@@ -32,7 +32,6 @@
 		"@shared/models": "^0.12.0-alpha.5",
 		"@shared/peripherals": "^0.12.0-alpha.5",
 		"cheerio": "^1.0.0",
-		"got": "^14.4.3",
 		"lodash-es": "^4.17.21",
 		"recursive-readdir": "^2.2.3",
 		"timeline-state-resolver": "^9.2.0",

--- a/shared/packages/tsr-bridge/src/sideload/CasparCGTemplates.ts
+++ b/shared/packages/tsr-bridge/src/sideload/CasparCGTemplates.ts
@@ -8,7 +8,6 @@ import * as cheerio from 'cheerio'
 import type { Element as domElement } from 'domhandler'
 
 import { CasparCG } from 'casparcg-connection'
-import got from 'got'
 import {
 	ResourceAny,
 	ResourceType,
@@ -63,7 +62,11 @@ export async function addTemplatesToResourcesFromCasparCGMediaScanner(
 	let jsonData: MediaScannerTemplateData | null = null
 
 	try {
-		jsonData = await got.get(`http://${casparCG.host}:8000/templates`).json()
+		const response = await fetch(`http://${casparCG.host}:8000/templates`)
+		if (!response.ok) {
+			throw new Error(`HTTP error! status: ${response.status}`)
+		}
+		jsonData = (await response.json()) as MediaScannerTemplateData
 	} catch {
 		// ignore
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2839,13 +2839,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sec-ant/readable-stream@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@sec-ant/readable-stream@npm:0.4.1"
-  checksum: 10c0/64e9e9cf161e848067a5bf60cdc04d18495dc28bb63a8d9f8993e4dd99b91ad34e4b563c85de17d91ffb177ec17a0664991d2e115f6543e73236a906068987af
-  languageName: node
-  linkType: hard
-
 "@shared/api@npm:^0.12.0-alpha.5, @shared/api@workspace:shared/packages/api":
   version: 0.0.0-use.local
   resolution: "@shared/api@workspace:shared/packages/api"
@@ -2920,7 +2913,6 @@ __metadata:
     "@shared/peripherals": "npm:^0.12.0-alpha.5"
     "@types/recursive-readdir": "npm:^2.2.4"
     cheerio: "npm:^1.0.0"
-    got: "npm:^14.4.3"
     lodash-es: "npm:^4.17.21"
     recursive-readdir: "npm:^2.2.3"
     timeline-state-resolver: "npm:^9.2.0"
@@ -3023,13 +3015,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sindresorhus/is@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "@sindresorhus/is@npm:7.0.1"
-  checksum: 10c0/6d43a916d70d9b64066394c272883869b22faf21f4748aaf399c1b691ea704ea607d1668ff2eb5704e5be8809c4a7faafe16be048ce5e1a2ba6e8928b8e3461c
-  languageName: node
-  linkType: hard
-
 "@sinonjs/commons@npm:^2.0.0":
   version: 2.0.0
   resolution: "@sinonjs/commons@npm:2.0.0"
@@ -3078,15 +3063,6 @@ __metadata:
   dependencies:
     defer-to-connect: "npm:^2.0.0"
   checksum: 10c0/73946918c025339db68b09abd91fa3001e87fc749c619d2e9c2003a663039d4c3cb89836c98a96598b3d47dec2481284ba85355392644911f5ecd2336536697f
-  languageName: node
-  linkType: hard
-
-"@szmarczak/http-timer@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@szmarczak/http-timer@npm:5.0.1"
-  dependencies:
-    defer-to-connect: "npm:^2.0.1"
-  checksum: 10c0/4629d2fbb2ea67c2e9dc03af235c0991c79ebdddcbc19aed5d5732fb29ce01c13331e9b1a491584b9069bd6ecde6581dcbf871f11b7eefdebbab34de6cf2197e
   languageName: node
   linkType: hard
 
@@ -3351,7 +3327,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/http-cache-semantics@npm:*, @types/http-cache-semantics@npm:^4.0.4":
+"@types/http-cache-semantics@npm:*":
   version: 4.0.4
   resolution: "@types/http-cache-semantics@npm:4.0.4"
   checksum: 10c0/51b72568b4b2863e0fe8d6ce8aad72a784b7510d72dc866215642da51d84945a9459fa89f49ec48f1e9a1752e6a78e85a4cda0ded06b1c73e727610c925f9ce6
@@ -4954,28 +4930,6 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"cacheable-lookup@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "cacheable-lookup@npm:7.0.0"
-  checksum: 10c0/63a9c144c5b45cb5549251e3ea774c04d63063b29e469f7584171d059d3a88f650f47869a974e2d07de62116463d742c287a81a625e791539d987115cb081635
-  languageName: node
-  linkType: hard
-
-"cacheable-request@npm:^12.0.1":
-  version: 12.0.1
-  resolution: "cacheable-request@npm:12.0.1"
-  dependencies:
-    "@types/http-cache-semantics": "npm:^4.0.4"
-    get-stream: "npm:^9.0.1"
-    http-cache-semantics: "npm:^4.1.1"
-    keyv: "npm:^4.5.4"
-    mimic-response: "npm:^4.0.0"
-    normalize-url: "npm:^8.0.1"
-    responselike: "npm:^3.0.0"
-  checksum: 10c0/3ccc26519c8dd0821fcb21fa00781e55f05ab6e1da1487fbbee9c8c03435a3cf72c29a710a991cebe398fb9a5274e2a772fc488546d402db8dc21310764ed83a
-  languageName: node
-  linkType: hard
-
 "cacheable-request@npm:^7.0.2":
   version: 7.0.2
   resolution: "cacheable-request@npm:7.0.2"
@@ -6115,7 +6069,7 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"defer-to-connect@npm:^2.0.0, defer-to-connect@npm:^2.0.1":
+"defer-to-connect@npm:^2.0.0":
   version: 2.0.1
   resolution: "defer-to-connect@npm:2.0.1"
   checksum: 10c0/625ce28e1b5ad10cf77057b9a6a727bf84780c17660f6644dab61dd34c23de3001f03cedc401f7d30a4ed9965c2e8a7336e220a329146f2cf85d4eddea429782
@@ -7629,13 +7583,6 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"form-data-encoder@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "form-data-encoder@npm:4.0.2"
-  checksum: 10c0/559d3130e265316452434eaf68d68560fb36392ff4d04614683419de4fb43c3dbe152dc303599fae382ce24d3451a6d3d289d3bcc182ae3d8ad32e7ce8e35e53
-  languageName: node
-  linkType: hard
-
 "form-data@npm:^4.0.0":
   version: 4.0.0
   resolution: "form-data@npm:4.0.0"
@@ -7970,16 +7917,6 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "get-stream@npm:9.0.1"
-  dependencies:
-    "@sec-ant/readable-stream": "npm:^0.4.1"
-    is-stream: "npm:^4.0.1"
-  checksum: 10c0/d70e73857f2eea1826ac570c3a912757dcfbe8a718a033fa0c23e12ac8e7d633195b01710e0559af574cbb5af101009b42df7b6f6b29ceec8dbdf7291931b948
-  languageName: node
-  linkType: hard
-
 "get-symbol-description@npm:^1.1.0":
   version: 1.1.0
   resolution: "get-symbol-description@npm:1.1.0"
@@ -8230,25 +8167,6 @@ asn1@evs-broadcast/node-asn1:
     p-cancelable: "npm:^2.0.0"
     responselike: "npm:^2.0.0"
   checksum: 10c0/754dd44877e5cf6183f1e989ff01c648d9a4719e357457bd4c78943911168881f1cfb7b2cb15d885e2105b3ad313adb8f017a67265dd7ade771afdb261ee8cb1
-  languageName: node
-  linkType: hard
-
-"got@npm:^14.4.3":
-  version: 14.4.7
-  resolution: "got@npm:14.4.7"
-  dependencies:
-    "@sindresorhus/is": "npm:^7.0.1"
-    "@szmarczak/http-timer": "npm:^5.0.1"
-    cacheable-lookup: "npm:^7.0.0"
-    cacheable-request: "npm:^12.0.1"
-    decompress-response: "npm:^6.0.0"
-    form-data-encoder: "npm:^4.0.2"
-    http2-wrapper: "npm:^2.2.1"
-    lowercase-keys: "npm:^3.0.0"
-    p-cancelable: "npm:^4.0.1"
-    responselike: "npm:^3.0.0"
-    type-fest: "npm:^4.26.1"
-  checksum: 10c0/9b5b8dbc0642c78dbc64ab5ff6f12f6edab3e0cb80e89a3a69623a79ba3986f0ff0066a116fba47c0aacce4b0ba1eccf72f923f7fac13a31ce852bf9e2cb8f81
   languageName: node
   linkType: hard
 
@@ -8522,16 +8440,6 @@ asn1@evs-broadcast/node-asn1:
     quick-lru: "npm:^5.1.1"
     resolve-alpn: "npm:^1.0.0"
   checksum: 10c0/6a9b72a033e9812e1476b9d776ce2f387bc94bc46c88aea0d5dab6bd47d0a539b8178830e77054dd26d1142c866d515a28a4dc7c3ff4232c88ff2ebe4f5d12d1
-  languageName: node
-  linkType: hard
-
-"http2-wrapper@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "http2-wrapper@npm:2.2.1"
-  dependencies:
-    quick-lru: "npm:^5.1.1"
-    resolve-alpn: "npm:^1.2.0"
-  checksum: 10c0/7207201d3c6e53e72e510c9b8912e4f3e468d3ecc0cf3bf52682f2aac9cd99358b896d1da4467380adc151cf97c412bedc59dc13dae90c523f42053a7449eedb
   languageName: node
   linkType: hard
 
@@ -9127,13 +9035,6 @@ asn1@evs-broadcast/node-asn1:
   version: 3.0.0
   resolution: "is-stream@npm:3.0.0"
   checksum: 10c0/eb2f7127af02ee9aa2a0237b730e47ac2de0d4e76a4a905a50a11557f2339df5765eaea4ceb8029f1efa978586abe776908720bfcb1900c20c6ec5145f6f29d8
-  languageName: node
-  linkType: hard
-
-"is-stream@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "is-stream@npm:4.0.1"
-  checksum: 10c0/2706c7f19b851327ba374687bc4a3940805e14ca496dc672b9629e744d143b1ad9c6f1b162dece81c7bfbc0f83b32b61ccc19ad2e05aad2dd7af347408f60c7f
   languageName: node
   linkType: hard
 
@@ -10678,13 +10579,6 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"lowercase-keys@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "lowercase-keys@npm:3.0.0"
-  checksum: 10c0/ef62b9fa5690ab0a6e4ef40c94efce68e3ed124f583cc3be38b26ff871da0178a28b9a84ce0c209653bb25ca135520ab87fea7cd411a54ac4899cb2f30501430
-  languageName: node
-  linkType: hard
-
 "lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0, lru-cache@npm:^10.2.2":
   version: 10.4.3
   resolution: "lru-cache@npm:10.4.3"
@@ -10941,13 +10835,6 @@ asn1@evs-broadcast/node-asn1:
   version: 3.1.0
   resolution: "mimic-response@npm:3.1.0"
   checksum: 10c0/0d6f07ce6e03e9e4445bee655202153bdb8a98d67ee8dc965ac140900d7a2688343e6b4c9a72cfc9ef2f7944dfd76eef4ab2482eb7b293a68b84916bac735362
-  languageName: node
-  linkType: hard
-
-"mimic-response@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "mimic-response@npm:4.0.0"
-  checksum: 10c0/761d788d2668ae9292c489605ffd4fad220f442fbae6832adce5ebad086d691e906a6d5240c290293c7a11e99fbdbbef04abbbed498bf8699a4ee0f31315e3fb
   languageName: node
   linkType: hard
 
@@ -11493,13 +11380,6 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "normalize-url@npm:8.0.1"
-  checksum: 10c0/eb439231c4b84430f187530e6fdac605c5048ef4ec556447a10c00a91fc69b52d8d8298d9d608e68d3e0f7dc2d812d3455edf425e0f215993667c3183bcab1ef
-  languageName: node
-  linkType: hard
-
 "notistack@npm:^3.0.1":
   version: 3.0.2
   resolution: "notistack@npm:3.0.2"
@@ -12005,13 +11885,6 @@ asn1@evs-broadcast/node-asn1:
   version: 2.1.1
   resolution: "p-cancelable@npm:2.1.1"
   checksum: 10c0/8c6dc1f8dd4154fd8b96a10e55a3a832684c4365fb9108056d89e79fbf21a2465027c04a59d0d797b5ffe10b54a61a32043af287d5c4860f1e996cbdbc847f01
-  languageName: node
-  linkType: hard
-
-"p-cancelable@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "p-cancelable@npm:4.0.1"
-  checksum: 10c0/12636623f46784ba962b6fe7a1f34d021f1d9a2cc12c43e270baa715ea872d5c8c7d9f086ed420b8b9817e91d9bbe92c14c90e5dddd4a9968c81a2a7aef7089d
   languageName: node
   linkType: hard
 
@@ -13218,7 +13091,7 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"resolve-alpn@npm:^1.0.0, resolve-alpn@npm:^1.2.0":
+"resolve-alpn@npm:^1.0.0":
   version: 1.2.1
   resolution: "resolve-alpn@npm:1.2.1"
   checksum: 10c0/b70b29c1843bc39781ef946c8cd4482e6d425976599c0f9c138cec8209e4e0736161bf39319b01676a847000085dfdaf63583c6fb4427bf751a10635bd2aa0c4
@@ -13330,15 +13203,6 @@ asn1@evs-broadcast/node-asn1:
   dependencies:
     lowercase-keys: "npm:^2.0.0"
   checksum: 10c0/653db4b1286f7a92bcd4d19463ac32687c0c1329d3e42c26e69b301197c583bcf40d77e910c1a6ac7cb7c3e8b6be1f1303d8e4168ad7c04db00397d8e70f5366
-  languageName: node
-  linkType: hard
-
-"responselike@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "responselike@npm:3.0.0"
-  dependencies:
-    lowercase-keys: "npm:^3.0.0"
-  checksum: 10c0/8af27153f7e47aa2c07a5f2d538cb1e5872995f0e9ff77def858ecce5c3fe677d42b824a62cde502e56d275ab832b0a8bd350d5cd6b467ac0425214ac12ae658
   languageName: node
   linkType: hard
 
@@ -14656,7 +14520,6 @@ asn1@evs-broadcast/node-asn1:
     electron-updater: "npm:^6.3.9"
     formik: "patch:formik@npm%3A2.2.9#~/.yarn/patches/formik-npm-2.2.9-0e8cb516ca.patch"
     formik-mui: "npm:^5.0.0-alpha.0"
-    got: "npm:^14.4.3"
     graphics-data-definition: "npm:1.1.1"
     jest: "npm:^29.7.0"
     koa: "npm:^2.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14677,7 +14677,7 @@ asn1@evs-broadcast/node-asn1:
     react-toggle: "patch:react-toggle@npm%3A4.1.3#~/.yarn/patches/react-toggle-npm-4.1.3-6397672405.patch"
     react-visibility-sensor: "npm:^5.1.1"
     sass: "npm:^1.79.4"
-    semver: "npm:^7.6.3"
+    semver: "npm:^7.7.1"
     short-uuid: "npm:^5.2.0"
     socket.io-client: "npm:^4.8.0"
     superfly-timeline: "npm:^8.3.1"


### PR DESCRIPTION
When I first tried to build SuperConductor, I got some errors from the "got" library. This library is deprecated as the built in fetch method is more than capable of replacing it modern JS.